### PR TITLE
add validAttributes to updated ViewConfig

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,7 @@ function fixReactNativeViewConfig(path) {
 
   const declaration = path.node.declarations[0];
   // validate that there is a name node and its value is what we expect
-  if (!declaration.id || !declaration.id.name || declaration.id.name !== 'ReactNativeViewConfig') {
+  if (!declaration.id || !declaration.id.name || (declaration.id.name !== 'ReactNativeViewConfig' && declaration.id.name !== 'PlatformBaseViewConfigIos' && declaration.id.name !== 'PlatformBaseViewConfigAndroid')) {
     return;
   }
 


### PR DESCRIPTION
`ReactNativeViewConfig` no longer exists in RN 71. Check for new objects to push `validAttributes`.

https://github.com/facebook/react-native/blob/714b502b0c7a5f897432dbad388c02d3b75b4689/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js#L331

https://github.com/facebook/react-native/blob/714b502b0c7a5f897432dbad388c02d3b75b4689/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js#L376