### PR TITLE
selectively disable view optimizations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -346,6 +346,32 @@ export default function({ types: t }) {
         fixReactNativeViewAttributes(path);
         fixTouchableMixin(t, path);
       },
+      JSXAttribute(path) {
+        if (path.parent.name.name !== 'View') return; 
+
+        if (
+          path.node.name.name !== 'fsClass' &&
+          path.node.name.name !== 'fsTagName' && 
+          path.node.name.name !== 'fsAttribute'
+        ) {
+          return;
+        }
+        
+        const isViewOptimizationDisabled = path.container.some(attribute => {
+          return t.isJSXIdentifier(attribute.name, { name: 'viewID' }) ||
+          t.isJSXIdentifier(attribute.name, { name: 'id' }) || 
+          t.isJSXIdentifier(attribute.name, { name: 'nativeID' });
+        })
+
+        if (isViewOptimizationDisabled) {
+          return;
+        }
+        
+				path.insertAfter(t.jsxAttribute(
+          t.jsxIdentifier('nativeID'),
+          t.stringLiteral('__FS_NATIVEID')
+        ))
+			}
     },
   };
 }


### PR DESCRIPTION
Fabric Android will perform view optimizations on layout only RN views and change the view hierarchy. As a result, FS SDK is unable to parse FS attributes due to view hierarchy changes. This change will add `nativeID` attribute on views with `fsClass`, `fsTagName`, or `fsAttribute` so that view optimization is disabled. 