### PR TITLE
add screen name as fsAttribute on screen root views

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -516,6 +516,9 @@ export default function ({ types: t }) {
         if (!isReactNavigationFile) {
           return;
         }
+        if (!t.isJSXIdentifier(path.node.name)) {
+          return;
+        }
 
         // rewrite all `<MaybeScreen />` components.
         const isMaybeScreenView = path.node.name.name === 'MaybeScreen';


### PR DESCRIPTION
Support React Navigation by adding `route.name` as `fsAttribute` onto screen root views. Originally looked into using `testID` but we currently do not detect `testID` changes on views due to attribute caching. `fsAttribute` changes will reset caches.