### PR TITLE
bugfix: import Platform in function body

### DIFF
--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
@@ -700,6 +700,7 @@ if (process.env.NODE_ENV !== 'production') {
      */
 
     var ReactElement = function (type, key, ref, self, source, owner, props) {
+      const { Platform } = require('react-native');
       const SUPPORTED_FS_ATTRIBUTES = [
         'fsClass',
         'fsAttribute',

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
@@ -806,6 +806,7 @@ if (process.env.NODE_ENV !== 'production') {
      */
 
     var ReactElement = function (type, key, ref, self, source, owner, props) {
+      const { Platform } = require('react-native');
       const SUPPORTED_FS_ATTRIBUTES = [
         'fsClass',
         'fsAttribute',

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
@@ -30,6 +30,7 @@ function q(c, a, g) {
   void 0 !== a.ref && (h = a.ref);
   for (b in a) m.call(a, b) && !p.hasOwnProperty(b) && (d[b] = a[b]);
   if (c && c.defaultProps) for (b in ((a = c.defaultProps), a)) void 0 === d[b] && (d[b] = a[b]);
+  const { Platform } = require('react-native');
   const SUPPORTED_FS_ATTRIBUTES = [
     'fsClass',
     'fsAttribute',

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
@@ -91,6 +91,7 @@ function M(a, b, e) {
     c.children = f;
   }
   if (a && a.defaultProps) for (d in ((g = a.defaultProps), g)) void 0 === c[d] && (c[d] = g[d]);
+  const { Platform } = require('react-native');
   const SUPPORTED_FS_ATTRIBUTES = [
     'fsClass',
     'fsAttribute',
@@ -315,6 +316,7 @@ exports.cloneElement = function (a, b, e) {
     for (var m = 0; m < f; m++) g[m] = arguments[m + 2];
     d.children = g;
   }
+  const { Platform } = require('react-native');
   const SUPPORTED_FS_ATTRIBUTES = [
     'fsClass',
     'fsAttribute',

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import * as t from '@babel/types';
 
 // We only add our ref to all Symbol(react.forward_ref) and Symbol(react.element) types, since they support refs
 const _createFabricRefCode = (refIdentifier, typeIdentifier, propsIdentifier) => `
+  const { Platform } = require('react-native');
   const SUPPORTED_FS_ATTRIBUTES = [
     'fsClass',
     'fsAttribute',


### PR DESCRIPTION
Our injected code exists in the [ReactElement](https://github.com/facebook/react/blob/bbb9cb116dbf7b6247721aa0c4bcb6ec249aa8af/packages/react/src/ReactElement.js#L149) function. It uses the `Platform` tool from `react-native`. Since the JS bundle exists in a single file, we currently depend on `Platform` existing in the global context. 

In Expo development build, something is causing `Platform` to not exist in the outer context, which is causing a crash. Let's import `Platform` in the function body itself to prevent depending on the unknown outer context. 