### PR TITLE
update the babel rewrites to send clicks to the RN plugin

### DIFF
--- a/__tests__/fixtures/react-native/pressability/output.js
+++ b/__tests__/fixtures/react-native/pressability/output.js
@@ -746,24 +746,18 @@ export default class Pressability {
     }
   }
   _onFsPressForward_Pressability(isLongPress) {
-    try {
-      if (!UIManager || !UIManager.onFsPressForward) {
-        return;
-      }
-    } catch (e) {
-      return;
-    }
     if (this._responderID == null) {
       return;
     }
     var nativeTag = null;
     if (typeof this._responderID === 'number') {
       nativeTag = this._responderID;
-    } else if (
-      typeof this._responderID === 'object' &&
-      typeof this._responderID._nativeTag === 'number'
-    ) {
-      nativeTag = this._responderID._nativeTag;
+    } else if (typeof this._responderID === 'object') {
+      if (typeof this._responderID._nativeTag === 'number') {
+        nativeTag = this._responderID._nativeTag;
+      } else if (typeof this._responderID.__nativeTag === 'number') {
+        nativeTag = this._responderID.__nativeTag;
+      }
     }
     if (nativeTag == null) {
       return;
@@ -771,7 +765,19 @@ export default class Pressability {
     const { onLongPress, onPress } = this._config;
     var hasPress = !!onPress;
     var hasLongPress = !!onLongPress;
-    UIManager.onFsPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+    try {
+      if (UIManager && UIManager.onFsPressForward) {
+        UIManager.onFsPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+        return;
+      }
+    } catch (e) {}
+    try {
+      var FullStory = require('@fullstory/react-native');
+      if (FullStory && FullStory.PrivateInterface && FullStory.PrivateInterface.onFSPressForward) {
+        FullStory.PrivateInterface.onFSPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+        return;
+      }
+    } catch (e) {}
   }
 }
 function normalizeDelay(delay: ?number, min = 0, fallback = 0): number {

--- a/__tests__/fixtures/react-native/touchable/output.js
+++ b/__tests__/fixtures/react-native/touchable/output.js
@@ -841,13 +841,6 @@ const TouchableMixin = {
   },
   withoutDefaultFocusAndBlur: ({}: $TEMPORARY$object<{||}>),
   _onFsPressForward: function (isLongPress) {
-    try {
-      if (!UIManager || !UIManager.onFsPressForward) {
-        return;
-      }
-    } catch (e) {
-      return;
-    }
     const tag = this.state.touchable.responderID;
     if (tag == null) {
       return;
@@ -855,15 +848,31 @@ const TouchableMixin = {
     var nativeTag = null;
     if (typeof tag === 'number') {
       nativeTag = tag;
-    } else if (typeof tag === 'object' && typeof tag._nativeTag === 'number') {
-      nativeTag = tag._nativeTag;
+    } else if (typeof tag === 'object') {
+      if (typeof tag._nativeTag === 'number') {
+        nativeTag = tag._nativeTag;
+      } else if (typeof tag.nativeID === 'number') {
+        nativeTag = tag.nativeID;
+      }
     }
     if (nativeTag == null) {
       return;
     }
     var hasPress = !!this.props.onPress;
     var hasLongPress = !!this.props.onLongPress;
-    UIManager.onFsPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+    try {
+      if (UIManager && UIManager.onFsPressForward) {
+        UIManager.onFsPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+        return;
+      }
+    } catch (e) {}
+    try {
+      var FullStory = require('@fullstory/react-native');
+      if (FullStory && FullStory.PrivateInterface && FullStory.PrivateInterface.onFSPressForward) {
+        FullStory.PrivateInterface.onFSPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+        return;
+      }
+    } catch (e) {}
   },
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,14 +30,6 @@ const _createFabricRefCode = (refIdentifier, typeIdentifier, propsIdentifier) =>
 // This is the code that we will generate for Pressability.
 // Note that `typeof UIManager` will cause an exception, so we use a try/catch.
 const _onFsPressForward_PressabilityCode = `_onFsPressForward_Pressability = function(isLongPress) {
-  try {
-    if (!UIManager || !UIManager.onFsPressForward) {
-      return;
-    }
-  } catch (e) {
-    return;
-  }
-
   if (this._responderID == null) {
     return;
   }
@@ -45,8 +37,12 @@ const _onFsPressForward_PressabilityCode = `_onFsPressForward_Pressability = fun
   var nativeTag = null;
   if (typeof this._responderID === 'number') {
     nativeTag = this._responderID;
-  } else if (typeof this._responderID === 'object' && typeof this._responderID._nativeTag === 'number') {
-    nativeTag = this._responderID._nativeTag
+  } else if (typeof this._responderID === 'object') {
+    if (typeof this._responderID._nativeTag === 'number') {
+      nativeTag = this._responderID._nativeTag
+    } else if (typeof this._responderID.__nativeTag === 'number') {
+      nativeTag = this._responderID.__nativeTag
+    }
   }
 
   if (nativeTag == null) {
@@ -57,7 +53,21 @@ const _onFsPressForward_PressabilityCode = `_onFsPressForward_Pressability = fun
 
   var hasPress = !!onPress;
   var hasLongPress = !!onLongPress;
-  UIManager.onFsPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+
+  try {
+    if (UIManager && UIManager.onFsPressForward) {
+      UIManager.onFsPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+      return;
+    }
+  } catch (e) {}
+
+  try {
+    var FullStory = require("@fullstory/react-native");
+    if (FullStory && FullStory.FullStoryPrivateAPI && FullStory.FullStoryPrivateAPI.onFSPressForward) {
+      FullStory.FullStoryPrivateAPI.onFSPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+      return;
+    }
+  } catch (e) {}
 }`;
 const _onFsPressForwardCallLongPress_PressabilityCode = `this._onFsPressForward_Pressability(true)`;
 const _onFsPressForwardCallPress_PressabilityCode = `this._onFsPressForward_Pressability(false)`;
@@ -78,14 +88,6 @@ const _onFsPressForwardCallPress_PressabilityAst = babylon.parseExpression(
 // This is the code that we will generate for Touchable.
 // Note that `typeof UIManager` will cause an exception, so we use a try/catch.
 const _onFsPressForwardCode = `_onFsPressForward = function(isLongPress) {
-  try {
-    if (!UIManager || !UIManager.onFsPressForward) {
-      return;
-    }
-  } catch (e) {
-    return;
-  }
-
   const tag = this.state.touchable.responderID;
   if (tag == null) {
     return;
@@ -94,8 +96,12 @@ const _onFsPressForwardCode = `_onFsPressForward = function(isLongPress) {
   var nativeTag = null;
   if (typeof tag === 'number') {
     nativeTag = tag;
-  } else if (typeof tag === 'object' && typeof tag._nativeTag === 'number') {
-    nativeTag = tag._nativeTag
+  } else if (typeof tag === 'object') {
+    if (typeof tag._nativeTag === 'number') {
+      nativeTag = tag._nativeTag
+    } else if (typeof tag.nativeID === 'number') {
+      nativeTag = tag.nativeID
+    }
   }
 
   if (nativeTag == null) {
@@ -104,7 +110,20 @@ const _onFsPressForwardCode = `_onFsPressForward = function(isLongPress) {
 
   var hasPress = !!this.props.onPress;
   var hasLongPress = !!this.props.onLongPress;
-  UIManager.onFsPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+  try {
+    if (UIManager && UIManager.onFsPressForward) {
+      UIManager.onFsPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+      return;
+    }
+  } catch (e) {}
+
+  try {
+    var FullStory = require("@fullstory/react-native");
+    if (FullStory && FullStory.FullStoryPrivateAPI && FullStory.FullStoryPrivateAPI.onFSPressForward) {
+      FullStory.FullStoryPrivateAPI.onFSPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+      return;
+    }
+  } catch (e) {}
 }`;
 const _onFsPressForwardCallLongPressCode = `this._onFsPressForward(true)`;
 const _onFsPressForwardCallPressCode = `this._onFsPressForward(false)`;

--- a/src/index.js
+++ b/src/index.js
@@ -63,8 +63,8 @@ const _onFsPressForward_PressabilityCode = `_onFsPressForward_Pressability = fun
 
   try {
     var FullStory = require("@fullstory/react-native");
-    if (FullStory && FullStory.FullStoryPrivateAPI && FullStory.FullStoryPrivateAPI.onFSPressForward) {
-      FullStory.FullStoryPrivateAPI.onFSPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+    if (FullStory && FullStory.PrivateInterface && FullStory.PrivateInterface.onFSPressForward) {
+      FullStory.PrivateInterface.onFSPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
       return;
     }
   } catch (e) {}
@@ -119,8 +119,8 @@ const _onFsPressForwardCode = `_onFsPressForward = function(isLongPress) {
 
   try {
     var FullStory = require("@fullstory/react-native");
-    if (FullStory && FullStory.FullStoryPrivateAPI && FullStory.FullStoryPrivateAPI.onFSPressForward) {
-      FullStory.FullStoryPrivateAPI.onFSPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
+    if (FullStory && FullStory.PrivateInterface && FullStory.PrivateInterface.onFSPressForward) {
+      FullStory.PrivateInterface.onFSPressForward(nativeTag, isLongPress, hasPress, hasLongPress);
       return;
     }
   } catch (e) {}

--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,9 @@ const _onFsPressForward_PressabilityCode = `_onFsPressForward_Pressability = fun
     nativeTag = this._responderID;
   } else if (typeof this._responderID === 'object') {
     if (typeof this._responderID._nativeTag === 'number') {
-      nativeTag = this._responderID._nativeTag
+      nativeTag = this._responderID._nativeTag;
     } else if (typeof this._responderID.__nativeTag === 'number') {
-      nativeTag = this._responderID.__nativeTag
+      nativeTag = this._responderID.__nativeTag;
     }
   }
 
@@ -49,7 +49,7 @@ const _onFsPressForward_PressabilityCode = `_onFsPressForward_Pressability = fun
     return;
   }
 
-  const {onLongPress, onPress} = this._config;
+  const { onLongPress, onPress } = this._config;
 
   var hasPress = !!onPress;
   var hasLongPress = !!onLongPress;
@@ -98,9 +98,9 @@ const _onFsPressForwardCode = `_onFsPressForward = function(isLongPress) {
     nativeTag = tag;
   } else if (typeof tag === 'object') {
     if (typeof tag._nativeTag === 'number') {
-      nativeTag = tag._nativeTag
+      nativeTag = tag._nativeTag;
     } else if (typeof tag.nativeID === 'number') {
-      nativeTag = tag.nativeID
+      nativeTag = tag.nativeID;
     }
   }
 


### PR DESCRIPTION
This PR updates our press forwarding logic to do the following:
1. `_onFsPressForward_PressabilityCode` now detects `this._responderID.__nativeTag` as a valid native tag field.
2. `_onFsPressForwardCode` now detects `tag.nativeID` as a valid native tag field.
3. Both press forwarding handlers will now check for `UIManager && UIManager.onFsPressForward` after resolving the tag and forward if it exists.
4. If the above does exist, then both handlers will check for `FullStory && FullStory.PrivateInterface && FullStory.PrivateInterface.onFSPressForward` and forward if that exists.


This will allow previously working RN <74 press forwarding on Android work, while also enabling RN 74+ press forwarding via a new FS private interface.