### PR TITLE
Fix new architecture detection

### DIFF
--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
@@ -709,7 +709,8 @@ if (process.env.NODE_ENV !== 'production') {
         'dataComponent',
         'dataSourceFile',
       ];
-      if (global.__turboModuleProxy != null && Platform.OS === 'ios') {
+      const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+      if (isTurboModuleEnabled && Platform.OS === 'ios') {
         if (
           type.$$typeof &&
           (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
@@ -815,7 +815,8 @@ if (process.env.NODE_ENV !== 'production') {
         'dataComponent',
         'dataSourceFile',
       ];
-      if (global.__turboModuleProxy != null && Platform.OS === 'ios') {
+      const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+      if (isTurboModuleEnabled && Platform.OS === 'ios') {
         if (
           type.$$typeof &&
           (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
@@ -39,7 +39,8 @@ function q(c, a, g) {
     'dataComponent',
     'dataSourceFile',
   ];
-  if (global.__turboModuleProxy != null && Platform.OS === 'ios') {
+  const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+  if (isTurboModuleEnabled && Platform.OS === 'ios') {
     if (
       c.$$typeof &&
       (c.$$typeof.toString() === 'Symbol(react.forward_ref)' ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
@@ -100,7 +100,8 @@ function M(a, b, e) {
     'dataComponent',
     'dataSourceFile',
   ];
-  if (global.__turboModuleProxy != null && Platform.OS === 'ios') {
+  const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+  if (isTurboModuleEnabled && Platform.OS === 'ios') {
     if (
       a.$$typeof &&
       (a.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
@@ -325,7 +326,8 @@ exports.cloneElement = function (a, b, e) {
     'dataComponent',
     'dataSourceFile',
   ];
-  if (global.__turboModuleProxy != null && Platform.OS === 'ios') {
+  const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+  if (isTurboModuleEnabled && Platform.OS === 'ios') {
     if (
       a.$$typeof &&
       (a.$$typeof.toString() === 'Symbol(react.forward_ref)' ||

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,9 @@ const _createFabricRefCode = (refIdentifier, typeIdentifier, propsIdentifier) =>
     'dataElement',
     'dataComponent',
     'dataSourceFile',
-  ];  
-  if (global.__turboModuleProxy != null && Platform.OS === 'ios') {
+  ]; 
+  const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null
+  if (isTurboModuleEnabled && Platform.OS === 'ios') {
     if (${typeIdentifier}.$$typeof && (${typeIdentifier}.$$typeof.toString() === 'Symbol(react.forward_ref)' || ${typeIdentifier}.$$typeof.toString() === 'Symbol(react.element)')) {
       if (${propsIdentifier}) {
         const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {


### PR DESCRIPTION
RN versions >=0.77 will use `global.RN$Bridgeless` as an indicator of whether New Architecture is enabled.