### PR TITLE
fix deploy CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: npm run test
       - persist_to_workspace:
           root: .
-          paths: .
+          paths: [.]
   deploy-babel-plugin-react-native:
     executor: browser-executor
     steps:
@@ -46,14 +46,21 @@ workflows:
   version: 2
   test-deploy:
     jobs:
-      - build-babel-plugin-react-native
+      - build-babel-plugin-react-native:
+          filters:
+            # test on all branches and tags (all branches are included by default)
+            tags:
+              only: /.*/
       - hold:
           type: approval
           requires:
             - build-babel-plugin-react-native
           filters:
+            # hold only on version tags
+            tags:
+              only: /^v.*/
             branches:
-              only: 'master'
+              ignore: /.*/
       - deploy-babel-plugin-react-native:
           requires:
             - hold


### PR DESCRIPTION
1.3.1 release did not trigger deploy

Making the configuration match [fullstory-react-native](https://github.com/fullstorydev/fullstory-react-native/blob/7d1b6dcef92a61222ac02bf7d4d19a90fc663c2e/.circleci/config.yml) in attempt to fix