### PR TITLE
WECA-1320: support react 19 in React Native 78

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
           name: Audit
-          command: npm audit --audit-level=low --production
+          command: npm audit --audit-level=low --omit=dev
       - run:
           name: Build
           command: npm run build

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
@@ -714,7 +714,8 @@ if (process.env.NODE_ENV !== 'production') {
         if (
           type.$$typeof &&
           (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-            type.$$typeof.toString() === 'Symbol(react.element)')
+            type.$$typeof.toString() === 'Symbol(react.element)' ||
+            type.$$typeof.toString() === 'Symbol(react.transitional.element)')
         ) {
           if (props) {
             const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/code.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/code.js
@@ -1,0 +1,1379 @@
+/**
+ * @license React
+ * react.development.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { applyFSPropertiesWithRef } = require('@fullstory/react-native/src');
+
+('use strict');
+'production' !== process.env.NODE_ENV &&
+  (function () {
+    function defineDeprecationWarning(methodName, info) {
+      Object.defineProperty(Component.prototype, methodName, {
+        get: function () {
+          console.warn(
+            '%s(...) is deprecated in plain JavaScript React classes. %s',
+            info[0],
+            info[1],
+          );
+        },
+      });
+    }
+    function getIteratorFn(maybeIterable) {
+      if (null === maybeIterable || 'object' !== typeof maybeIterable) return null;
+      maybeIterable =
+        (MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL]) ||
+        maybeIterable['@@iterator'];
+      return 'function' === typeof maybeIterable ? maybeIterable : null;
+    }
+    function warnNoop(publicInstance, callerName) {
+      publicInstance =
+        ((publicInstance = publicInstance.constructor) &&
+          (publicInstance.displayName || publicInstance.name)) ||
+        'ReactClass';
+      var warningKey = publicInstance + '.' + callerName;
+      didWarnStateUpdateForUnmountedComponent[warningKey] ||
+        (console.error(
+          "Can't call %s on a component that is not yet mounted. This is a no-op, but it might indicate a bug in your application. Instead, assign to `this.state` directly or define a `state = {};` class property with the desired state in the %s component.",
+          callerName,
+          publicInstance,
+        ),
+        (didWarnStateUpdateForUnmountedComponent[warningKey] = !0));
+    }
+    function Component(props, context, updater) {
+      this.props = props;
+      this.context = context;
+      this.refs = emptyObject;
+      this.updater = updater || ReactNoopUpdateQueue;
+    }
+    function ComponentDummy() {}
+    function PureComponent(props, context, updater) {
+      this.props = props;
+      this.context = context;
+      this.refs = emptyObject;
+      this.updater = updater || ReactNoopUpdateQueue;
+    }
+    function testStringCoercion(value) {
+      return '' + value;
+    }
+    function checkKeyStringCoercion(value) {
+      try {
+        testStringCoercion(value);
+        var JSCompiler_inline_result = !1;
+      } catch (e) {
+        JSCompiler_inline_result = !0;
+      }
+      if (JSCompiler_inline_result) {
+        JSCompiler_inline_result = console;
+        var JSCompiler_temp_const = JSCompiler_inline_result.error;
+        var JSCompiler_inline_result$jscomp$0 =
+          ('function' === typeof Symbol && Symbol.toStringTag && value[Symbol.toStringTag]) ||
+          value.constructor.name ||
+          'Object';
+        JSCompiler_temp_const.call(
+          JSCompiler_inline_result,
+          'The provided key is an unsupported type %s. This value must be coerced to a string before using it here.',
+          JSCompiler_inline_result$jscomp$0,
+        );
+        return testStringCoercion(value);
+      }
+    }
+    function getComponentNameFromType(type) {
+      if (null == type) return null;
+      if ('function' === typeof type)
+        return type.$$typeof === REACT_CLIENT_REFERENCE$2
+          ? null
+          : type.displayName || type.name || null;
+      if ('string' === typeof type) return type;
+      switch (type) {
+        case REACT_FRAGMENT_TYPE:
+          return 'Fragment';
+        case REACT_PORTAL_TYPE:
+          return 'Portal';
+        case REACT_PROFILER_TYPE:
+          return 'Profiler';
+        case REACT_STRICT_MODE_TYPE:
+          return 'StrictMode';
+        case REACT_SUSPENSE_TYPE:
+          return 'Suspense';
+        case REACT_SUSPENSE_LIST_TYPE:
+          return 'SuspenseList';
+      }
+      if ('object' === typeof type)
+        switch (
+          ('number' === typeof type.tag &&
+            console.error(
+              'Received an unexpected object in getComponentNameFromType(). This is likely a bug in React. Please file an issue.',
+            ),
+          type.$$typeof)
+        ) {
+          case REACT_CONTEXT_TYPE:
+            return (type.displayName || 'Context') + '.Provider';
+          case REACT_CONSUMER_TYPE:
+            return (type._context.displayName || 'Context') + '.Consumer';
+          case REACT_FORWARD_REF_TYPE:
+            var innerType = type.render;
+            type = type.displayName;
+            type ||
+              ((type = innerType.displayName || innerType.name || ''),
+              (type = '' !== type ? 'ForwardRef(' + type + ')' : 'ForwardRef'));
+            return type;
+          case REACT_MEMO_TYPE:
+            return (
+              (innerType = type.displayName || null),
+              null !== innerType ? innerType : getComponentNameFromType(type.type) || 'Memo'
+            );
+          case REACT_LAZY_TYPE:
+            innerType = type._payload;
+            type = type._init;
+            try {
+              return getComponentNameFromType(type(innerType));
+            } catch (x) {}
+        }
+      return null;
+    }
+    function isValidElementType(type) {
+      return 'string' === typeof type ||
+        'function' === typeof type ||
+        type === REACT_FRAGMENT_TYPE ||
+        type === REACT_PROFILER_TYPE ||
+        type === REACT_STRICT_MODE_TYPE ||
+        type === REACT_SUSPENSE_TYPE ||
+        type === REACT_SUSPENSE_LIST_TYPE ||
+        type === REACT_OFFSCREEN_TYPE ||
+        ('object' === typeof type &&
+          null !== type &&
+          (type.$$typeof === REACT_LAZY_TYPE ||
+            type.$$typeof === REACT_MEMO_TYPE ||
+            type.$$typeof === REACT_CONTEXT_TYPE ||
+            type.$$typeof === REACT_CONSUMER_TYPE ||
+            type.$$typeof === REACT_FORWARD_REF_TYPE ||
+            type.$$typeof === REACT_CLIENT_REFERENCE$1 ||
+            void 0 !== type.getModuleId))
+        ? !0
+        : !1;
+    }
+    function disabledLog() {}
+    function disableLogs() {
+      if (0 === disabledDepth) {
+        prevLog = console.log;
+        prevInfo = console.info;
+        prevWarn = console.warn;
+        prevError = console.error;
+        prevGroup = console.group;
+        prevGroupCollapsed = console.groupCollapsed;
+        prevGroupEnd = console.groupEnd;
+        var props = {
+          configurable: !0,
+          enumerable: !0,
+          value: disabledLog,
+          writable: !0,
+        };
+        Object.defineProperties(console, {
+          info: props,
+          log: props,
+          warn: props,
+          error: props,
+          group: props,
+          groupCollapsed: props,
+          groupEnd: props,
+        });
+      }
+      disabledDepth++;
+    }
+    function reenableLogs() {
+      disabledDepth--;
+      if (0 === disabledDepth) {
+        var props = { configurable: !0, enumerable: !0, writable: !0 };
+        Object.defineProperties(console, {
+          log: assign({}, props, { value: prevLog }),
+          info: assign({}, props, { value: prevInfo }),
+          warn: assign({}, props, { value: prevWarn }),
+          error: assign({}, props, { value: prevError }),
+          group: assign({}, props, { value: prevGroup }),
+          groupCollapsed: assign({}, props, { value: prevGroupCollapsed }),
+          groupEnd: assign({}, props, { value: prevGroupEnd }),
+        });
+      }
+      0 > disabledDepth &&
+        console.error(
+          'disabledDepth fell below zero. This is a bug in React. Please file an issue.',
+        );
+    }
+    function describeBuiltInComponentFrame(name) {
+      if (void 0 === prefix)
+        try {
+          throw Error();
+        } catch (x) {
+          var match = x.stack.trim().match(/\n( *(at )?)/);
+          prefix = (match && match[1]) || '';
+          suffix =
+            -1 < x.stack.indexOf('\n    at')
+              ? ' (<anonymous>)'
+              : -1 < x.stack.indexOf('@')
+              ? '@unknown:0:0'
+              : '';
+        }
+      return '\n' + prefix + name + suffix;
+    }
+    function describeNativeComponentFrame(fn, construct) {
+      if (!fn || reentry) return '';
+      var frame = componentFrameCache.get(fn);
+      if (void 0 !== frame) return frame;
+      reentry = !0;
+      frame = Error.prepareStackTrace;
+      Error.prepareStackTrace = void 0;
+      var previousDispatcher = null;
+      previousDispatcher = ReactSharedInternals.H;
+      ReactSharedInternals.H = null;
+      disableLogs();
+      try {
+        var RunInRootFrame = {
+          DetermineComponentFrameRoot: function () {
+            try {
+              if (construct) {
+                var Fake = function () {
+                  throw Error();
+                };
+                Object.defineProperty(Fake.prototype, 'props', {
+                  set: function () {
+                    throw Error();
+                  },
+                });
+                if ('object' === typeof Reflect && Reflect.construct) {
+                  try {
+                    Reflect.construct(Fake, []);
+                  } catch (x) {
+                    var control = x;
+                  }
+                  Reflect.construct(fn, [], Fake);
+                } else {
+                  try {
+                    Fake.call();
+                  } catch (x$0) {
+                    control = x$0;
+                  }
+                  fn.call(Fake.prototype);
+                }
+              } else {
+                try {
+                  throw Error();
+                } catch (x$1) {
+                  control = x$1;
+                }
+                (Fake = fn()) && 'function' === typeof Fake.catch && Fake.catch(function () {});
+              }
+            } catch (sample) {
+              if (sample && control && 'string' === typeof sample.stack)
+                return [sample.stack, control.stack];
+            }
+            return [null, null];
+          },
+        };
+        RunInRootFrame.DetermineComponentFrameRoot.displayName = 'DetermineComponentFrameRoot';
+        var namePropDescriptor = Object.getOwnPropertyDescriptor(
+          RunInRootFrame.DetermineComponentFrameRoot,
+          'name',
+        );
+        namePropDescriptor &&
+          namePropDescriptor.configurable &&
+          Object.defineProperty(RunInRootFrame.DetermineComponentFrameRoot, 'name', {
+            value: 'DetermineComponentFrameRoot',
+          });
+        var _RunInRootFrame$Deter = RunInRootFrame.DetermineComponentFrameRoot(),
+          sampleStack = _RunInRootFrame$Deter[0],
+          controlStack = _RunInRootFrame$Deter[1];
+        if (sampleStack && controlStack) {
+          var sampleLines = sampleStack.split('\n'),
+            controlLines = controlStack.split('\n');
+          for (
+            _RunInRootFrame$Deter = namePropDescriptor = 0;
+            namePropDescriptor < sampleLines.length &&
+            !sampleLines[namePropDescriptor].includes('DetermineComponentFrameRoot');
+
+          )
+            namePropDescriptor++;
+          for (
+            ;
+            _RunInRootFrame$Deter < controlLines.length &&
+            !controlLines[_RunInRootFrame$Deter].includes('DetermineComponentFrameRoot');
+
+          )
+            _RunInRootFrame$Deter++;
+          if (
+            namePropDescriptor === sampleLines.length ||
+            _RunInRootFrame$Deter === controlLines.length
+          )
+            for (
+              namePropDescriptor = sampleLines.length - 1,
+                _RunInRootFrame$Deter = controlLines.length - 1;
+              1 <= namePropDescriptor &&
+              0 <= _RunInRootFrame$Deter &&
+              sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter];
+
+            )
+              _RunInRootFrame$Deter--;
+          for (
+            ;
+            1 <= namePropDescriptor && 0 <= _RunInRootFrame$Deter;
+            namePropDescriptor--, _RunInRootFrame$Deter--
+          )
+            if (sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter]) {
+              if (1 !== namePropDescriptor || 1 !== _RunInRootFrame$Deter) {
+                do
+                  if (
+                    (namePropDescriptor--,
+                    _RunInRootFrame$Deter--,
+                    0 > _RunInRootFrame$Deter ||
+                      sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter])
+                  ) {
+                    var _frame = '\n' + sampleLines[namePropDescriptor].replace(' at new ', ' at ');
+                    fn.displayName &&
+                      _frame.includes('<anonymous>') &&
+                      (_frame = _frame.replace('<anonymous>', fn.displayName));
+                    'function' === typeof fn && componentFrameCache.set(fn, _frame);
+                    return _frame;
+                  }
+                while (1 <= namePropDescriptor && 0 <= _RunInRootFrame$Deter);
+              }
+              break;
+            }
+        }
+      } finally {
+        (reentry = !1),
+          (ReactSharedInternals.H = previousDispatcher),
+          reenableLogs(),
+          (Error.prepareStackTrace = frame);
+      }
+      sampleLines = (sampleLines = fn ? fn.displayName || fn.name : '')
+        ? describeBuiltInComponentFrame(sampleLines)
+        : '';
+      'function' === typeof fn && componentFrameCache.set(fn, sampleLines);
+      return sampleLines;
+    }
+    function describeUnknownElementTypeFrameInDEV(type) {
+      if (null == type) return '';
+      if ('function' === typeof type) {
+        var prototype = type.prototype;
+        return describeNativeComponentFrame(type, !(!prototype || !prototype.isReactComponent));
+      }
+      if ('string' === typeof type) return describeBuiltInComponentFrame(type);
+      switch (type) {
+        case REACT_SUSPENSE_TYPE:
+          return describeBuiltInComponentFrame('Suspense');
+        case REACT_SUSPENSE_LIST_TYPE:
+          return describeBuiltInComponentFrame('SuspenseList');
+      }
+      if ('object' === typeof type)
+        switch (type.$$typeof) {
+          case REACT_FORWARD_REF_TYPE:
+            return (type = describeNativeComponentFrame(type.render, !1)), type;
+          case REACT_MEMO_TYPE:
+            return describeUnknownElementTypeFrameInDEV(type.type);
+          case REACT_LAZY_TYPE:
+            prototype = type._payload;
+            type = type._init;
+            try {
+              return describeUnknownElementTypeFrameInDEV(type(prototype));
+            } catch (x) {}
+        }
+      return '';
+    }
+    function getOwner() {
+      var dispatcher = ReactSharedInternals.A;
+      return null === dispatcher ? null : dispatcher.getOwner();
+    }
+    function hasValidKey(config) {
+      if (hasOwnProperty.call(config, 'key')) {
+        var getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+        if (getter && getter.isReactWarning) return !1;
+      }
+      return void 0 !== config.key;
+    }
+    function defineKeyPropWarningGetter(props, displayName) {
+      function warnAboutAccessingKey() {
+        specialPropKeyWarningShown ||
+          ((specialPropKeyWarningShown = !0),
+          console.error(
+            '%s: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://react.dev/link/special-props)',
+            displayName,
+          ));
+      }
+      warnAboutAccessingKey.isReactWarning = !0;
+      Object.defineProperty(props, 'key', {
+        get: warnAboutAccessingKey,
+        configurable: !0,
+      });
+    }
+    function elementRefGetterWithDeprecationWarning() {
+      var componentName = getComponentNameFromType(this.type);
+      didWarnAboutElementRef[componentName] ||
+        ((didWarnAboutElementRef[componentName] = !0),
+        console.error(
+          'Accessing element.ref was removed in React 19. ref is now a regular prop. It will be removed from the JSX Element type in a future release.',
+        ));
+      componentName = this.props.ref;
+      return void 0 !== componentName ? componentName : null;
+    }
+    function ReactElement(type, key, self, source, owner, props) {
+      props = { ...props, ref: applyFSPropertiesWithRef(props.ref) };
+      self = props.ref;
+      type = {
+        $$typeof: REACT_ELEMENT_TYPE,
+        type: type,
+        key: key,
+        props: props,
+        _owner: owner,
+      };
+      null !== (void 0 !== self ? self : null)
+        ? Object.defineProperty(type, 'ref', {
+            enumerable: !1,
+            get: elementRefGetterWithDeprecationWarning,
+          })
+        : Object.defineProperty(type, 'ref', { enumerable: !1, value: null });
+      type._store = {};
+      Object.defineProperty(type._store, 'validated', {
+        configurable: !1,
+        enumerable: !1,
+        writable: !0,
+        value: 0,
+      });
+      Object.defineProperty(type, '_debugInfo', {
+        configurable: !1,
+        enumerable: !1,
+        writable: !0,
+        value: null,
+      });
+      Object.freeze && (Object.freeze(type.props), Object.freeze(type));
+      return type;
+    }
+    function cloneAndReplaceKey(oldElement, newKey) {
+      newKey = ReactElement(
+        oldElement.type,
+        newKey,
+        void 0,
+        void 0,
+        oldElement._owner,
+        oldElement.props,
+      );
+      newKey._store.validated = oldElement._store.validated;
+      return newKey;
+    }
+    function validateChildKeys(node, parentType) {
+      if ('object' === typeof node && node && node.$$typeof !== REACT_CLIENT_REFERENCE)
+        if (isArrayImpl(node))
+          for (var i = 0; i < node.length; i++) {
+            var child = node[i];
+            isValidElement(child) && validateExplicitKey(child, parentType);
+          }
+        else if (isValidElement(node)) node._store && (node._store.validated = 1);
+        else if (
+          ((i = getIteratorFn(node)),
+          'function' === typeof i && i !== node.entries && ((i = i.call(node)), i !== node))
+        )
+          for (; !(node = i.next()).done; )
+            isValidElement(node.value) && validateExplicitKey(node.value, parentType);
+    }
+    function isValidElement(object) {
+      return (
+        'object' === typeof object && null !== object && object.$$typeof === REACT_ELEMENT_TYPE
+      );
+    }
+    function validateExplicitKey(element, parentType) {
+      if (
+        element._store &&
+        !element._store.validated &&
+        null == element.key &&
+        ((element._store.validated = 1),
+        (parentType = getCurrentComponentErrorInfo(parentType)),
+        !ownerHasKeyUseWarning[parentType])
+      ) {
+        ownerHasKeyUseWarning[parentType] = !0;
+        var childOwner = '';
+        element &&
+          null != element._owner &&
+          element._owner !== getOwner() &&
+          ((childOwner = null),
+          'number' === typeof element._owner.tag
+            ? (childOwner = getComponentNameFromType(element._owner.type))
+            : 'string' === typeof element._owner.name && (childOwner = element._owner.name),
+          (childOwner = ' It was passed a child from ' + childOwner + '.'));
+        var prevGetCurrentStack = ReactSharedInternals.getCurrentStack;
+        ReactSharedInternals.getCurrentStack = function () {
+          var stack = describeUnknownElementTypeFrameInDEV(element.type);
+          prevGetCurrentStack && (stack += prevGetCurrentStack() || '');
+          return stack;
+        };
+        console.error(
+          'Each child in a list should have a unique "key" prop.%s%s See https://react.dev/link/warning-keys for more information.',
+          parentType,
+          childOwner,
+        );
+        ReactSharedInternals.getCurrentStack = prevGetCurrentStack;
+      }
+    }
+    function getCurrentComponentErrorInfo(parentType) {
+      var info = '',
+        owner = getOwner();
+      owner &&
+        (owner = getComponentNameFromType(owner.type)) &&
+        (info = '\n\nCheck the render method of `' + owner + '`.');
+      info ||
+        ((parentType = getComponentNameFromType(parentType)) &&
+          (info = '\n\nCheck the top-level render call using <' + parentType + '>.'));
+      return info;
+    }
+    function escape(key) {
+      var escaperLookup = { '=': '=0', ':': '=2' };
+      return (
+        '$' +
+        key.replace(/[=:]/g, function (match) {
+          return escaperLookup[match];
+        })
+      );
+    }
+    function getElementKey(element, index) {
+      return 'object' === typeof element && null !== element && null != element.key
+        ? (checkKeyStringCoercion(element.key), escape('' + element.key))
+        : index.toString(36);
+    }
+    function noop$1() {}
+    function resolveThenable(thenable) {
+      switch (thenable.status) {
+        case 'fulfilled':
+          return thenable.value;
+        case 'rejected':
+          throw thenable.reason;
+        default:
+          switch (
+            ('string' === typeof thenable.status
+              ? thenable.then(noop$1, noop$1)
+              : ((thenable.status = 'pending'),
+                thenable.then(
+                  function (fulfilledValue) {
+                    'pending' === thenable.status &&
+                      ((thenable.status = 'fulfilled'), (thenable.value = fulfilledValue));
+                  },
+                  function (error) {
+                    'pending' === thenable.status &&
+                      ((thenable.status = 'rejected'), (thenable.reason = error));
+                  },
+                )),
+            thenable.status)
+          ) {
+            case 'fulfilled':
+              return thenable.value;
+            case 'rejected':
+              throw thenable.reason;
+          }
+      }
+      throw thenable;
+    }
+    function mapIntoArray(children, array, escapedPrefix, nameSoFar, callback) {
+      var type = typeof children;
+      if ('undefined' === type || 'boolean' === type) children = null;
+      var invokeCallback = !1;
+      if (null === children) invokeCallback = !0;
+      else
+        switch (type) {
+          case 'bigint':
+          case 'string':
+          case 'number':
+            invokeCallback = !0;
+            break;
+          case 'object':
+            switch (children.$$typeof) {
+              case REACT_ELEMENT_TYPE:
+              case REACT_PORTAL_TYPE:
+                invokeCallback = !0;
+                break;
+              case REACT_LAZY_TYPE:
+                return (
+                  (invokeCallback = children._init),
+                  mapIntoArray(
+                    invokeCallback(children._payload),
+                    array,
+                    escapedPrefix,
+                    nameSoFar,
+                    callback,
+                  )
+                );
+            }
+        }
+      if (invokeCallback) {
+        invokeCallback = children;
+        callback = callback(invokeCallback);
+        var childKey = '' === nameSoFar ? '.' + getElementKey(invokeCallback, 0) : nameSoFar;
+        isArrayImpl(callback)
+          ? ((escapedPrefix = ''),
+            null != childKey &&
+              (escapedPrefix = childKey.replace(userProvidedKeyEscapeRegex, '$&/') + '/'),
+            mapIntoArray(callback, array, escapedPrefix, '', function (c) {
+              return c;
+            }))
+          : null != callback &&
+            (isValidElement(callback) &&
+              (null != callback.key &&
+                ((invokeCallback && invokeCallback.key === callback.key) ||
+                  checkKeyStringCoercion(callback.key)),
+              (escapedPrefix = cloneAndReplaceKey(
+                callback,
+                escapedPrefix +
+                  (null == callback.key || (invokeCallback && invokeCallback.key === callback.key)
+                    ? ''
+                    : ('' + callback.key).replace(userProvidedKeyEscapeRegex, '$&/') + '/') +
+                  childKey,
+              )),
+              '' !== nameSoFar &&
+                null != invokeCallback &&
+                isValidElement(invokeCallback) &&
+                null == invokeCallback.key &&
+                invokeCallback._store &&
+                !invokeCallback._store.validated &&
+                (escapedPrefix._store.validated = 2),
+              (callback = escapedPrefix)),
+            array.push(callback));
+        return 1;
+      }
+      invokeCallback = 0;
+      childKey = '' === nameSoFar ? '.' : nameSoFar + ':';
+      if (isArrayImpl(children))
+        for (var i = 0; i < children.length; i++)
+          (nameSoFar = children[i]),
+            (type = childKey + getElementKey(nameSoFar, i)),
+            (invokeCallback += mapIntoArray(nameSoFar, array, escapedPrefix, type, callback));
+      else if (((i = getIteratorFn(children)), 'function' === typeof i))
+        for (
+          i === children.entries &&
+            (didWarnAboutMaps ||
+              console.warn(
+                'Using Maps as children is not supported. Use an array of keyed ReactElements instead.',
+              ),
+            (didWarnAboutMaps = !0)),
+            children = i.call(children),
+            i = 0;
+          !(nameSoFar = children.next()).done;
+
+        )
+          (nameSoFar = nameSoFar.value),
+            (type = childKey + getElementKey(nameSoFar, i++)),
+            (invokeCallback += mapIntoArray(nameSoFar, array, escapedPrefix, type, callback));
+      else if ('object' === type) {
+        if ('function' === typeof children.then)
+          return mapIntoArray(resolveThenable(children), array, escapedPrefix, nameSoFar, callback);
+        array = String(children);
+        throw Error(
+          'Objects are not valid as a React child (found: ' +
+            ('[object Object]' === array
+              ? 'object with keys {' + Object.keys(children).join(', ') + '}'
+              : array) +
+            '). If you meant to render a collection of children, use an array instead.',
+        );
+      }
+      return invokeCallback;
+    }
+    function mapChildren(children, func, context) {
+      if (null == children) return children;
+      var result = [],
+        count = 0;
+      mapIntoArray(children, result, '', '', function (child) {
+        return func.call(context, child, count++);
+      });
+      return result;
+    }
+    function lazyInitializer(payload) {
+      if (-1 === payload._status) {
+        var ctor = payload._result;
+        ctor = ctor();
+        ctor.then(
+          function (moduleObject) {
+            if (0 === payload._status || -1 === payload._status)
+              (payload._status = 1), (payload._result = moduleObject);
+          },
+          function (error) {
+            if (0 === payload._status || -1 === payload._status)
+              (payload._status = 2), (payload._result = error);
+          },
+        );
+        -1 === payload._status && ((payload._status = 0), (payload._result = ctor));
+      }
+      if (1 === payload._status)
+        return (
+          (ctor = payload._result),
+          void 0 === ctor &&
+            console.error(
+              "lazy: Expected the result of a dynamic import() call. Instead received: %s\n\nYour code should look like: \n  const MyComponent = lazy(() => import('./MyComponent'))\n\nDid you accidentally put curly braces around the import?",
+              ctor,
+            ),
+          'default' in ctor ||
+            console.error(
+              "lazy: Expected the result of a dynamic import() call. Instead received: %s\n\nYour code should look like: \n  const MyComponent = lazy(() => import('./MyComponent'))",
+              ctor,
+            ),
+          ctor.default
+        );
+      throw payload._result;
+    }
+    function resolveDispatcher() {
+      var dispatcher = ReactSharedInternals.H;
+      null === dispatcher &&
+        console.error(
+          'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem.',
+        );
+      return dispatcher;
+    }
+    function noop() {}
+    function enqueueTask(task) {
+      if (null === enqueueTaskImpl)
+        try {
+          var requireString = ('require' + Math.random()).slice(0, 7);
+          enqueueTaskImpl = (module && module[requireString]).call(module, 'timers').setImmediate;
+        } catch (_err) {
+          enqueueTaskImpl = function (callback) {
+            !1 === didWarnAboutMessageChannel &&
+              ((didWarnAboutMessageChannel = !0),
+              'undefined' === typeof MessageChannel &&
+                console.error(
+                  'This browser does not have a MessageChannel implementation, so enqueuing tasks via await act(async () => ...) will fail. Please file an issue at https://github.com/facebook/react/issues if you encounter this warning.',
+                ));
+            var channel = new MessageChannel();
+            channel.port1.onmessage = callback;
+            channel.port2.postMessage(void 0);
+          };
+        }
+      return enqueueTaskImpl(task);
+    }
+    function aggregateErrors(errors) {
+      return 1 < errors.length && 'function' === typeof AggregateError
+        ? new AggregateError(errors)
+        : errors[0];
+    }
+    function popActScope(prevActQueue, prevActScopeDepth) {
+      prevActScopeDepth !== actScopeDepth - 1 &&
+        console.error(
+          'You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one. ',
+        );
+      actScopeDepth = prevActScopeDepth;
+    }
+    function recursivelyFlushAsyncActWork(returnValue, resolve, reject) {
+      var queue = ReactSharedInternals.actQueue;
+      if (null !== queue)
+        if (0 !== queue.length)
+          try {
+            flushActQueue(queue);
+            enqueueTask(function () {
+              return recursivelyFlushAsyncActWork(returnValue, resolve, reject);
+            });
+            return;
+          } catch (error) {
+            ReactSharedInternals.thrownErrors.push(error);
+          }
+        else ReactSharedInternals.actQueue = null;
+      0 < ReactSharedInternals.thrownErrors.length
+        ? ((queue = aggregateErrors(ReactSharedInternals.thrownErrors)),
+          (ReactSharedInternals.thrownErrors.length = 0),
+          reject(queue))
+        : resolve(returnValue);
+    }
+    function flushActQueue(queue) {
+      if (!isFlushing) {
+        isFlushing = !0;
+        var i = 0;
+        try {
+          for (; i < queue.length; i++) {
+            var callback = queue[i];
+            do {
+              ReactSharedInternals.didUsePromise = !1;
+              var continuation = callback(!1);
+              if (null !== continuation) {
+                if (ReactSharedInternals.didUsePromise) {
+                  queue[i] = callback;
+                  queue.splice(0, i);
+                  return;
+                }
+                callback = continuation;
+              } else break;
+            } while (1);
+          }
+          queue.length = 0;
+        } catch (error) {
+          queue.splice(0, i + 1), ReactSharedInternals.thrownErrors.push(error);
+        } finally {
+          isFlushing = !1;
+        }
+      }
+    }
+    'undefined' !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ &&
+      'function' === typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart &&
+      __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart(Error());
+    var REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
+      REACT_PORTAL_TYPE = Symbol.for('react.portal'),
+      REACT_FRAGMENT_TYPE = Symbol.for('react.fragment'),
+      REACT_STRICT_MODE_TYPE = Symbol.for('react.strict_mode'),
+      REACT_PROFILER_TYPE = Symbol.for('react.profiler');
+    Symbol.for('react.provider');
+    var REACT_CONSUMER_TYPE = Symbol.for('react.consumer'),
+      REACT_CONTEXT_TYPE = Symbol.for('react.context'),
+      REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref'),
+      REACT_SUSPENSE_TYPE = Symbol.for('react.suspense'),
+      REACT_SUSPENSE_LIST_TYPE = Symbol.for('react.suspense_list'),
+      REACT_MEMO_TYPE = Symbol.for('react.memo'),
+      REACT_LAZY_TYPE = Symbol.for('react.lazy'),
+      REACT_OFFSCREEN_TYPE = Symbol.for('react.offscreen'),
+      MAYBE_ITERATOR_SYMBOL = Symbol.iterator,
+      didWarnStateUpdateForUnmountedComponent = {},
+      ReactNoopUpdateQueue = {
+        isMounted: function () {
+          return !1;
+        },
+        enqueueForceUpdate: function (publicInstance) {
+          warnNoop(publicInstance, 'forceUpdate');
+        },
+        enqueueReplaceState: function (publicInstance) {
+          warnNoop(publicInstance, 'replaceState');
+        },
+        enqueueSetState: function (publicInstance) {
+          warnNoop(publicInstance, 'setState');
+        },
+      },
+      assign = Object.assign,
+      emptyObject = {};
+    Object.freeze(emptyObject);
+    Component.prototype.isReactComponent = {};
+    Component.prototype.setState = function (partialState, callback) {
+      if (
+        'object' !== typeof partialState &&
+        'function' !== typeof partialState &&
+        null != partialState
+      )
+        throw Error(
+          'takes an object of state variables to update or a function which returns an object of state variables.',
+        );
+      this.updater.enqueueSetState(this, partialState, callback, 'setState');
+    };
+    Component.prototype.forceUpdate = function (callback) {
+      this.updater.enqueueForceUpdate(this, callback, 'forceUpdate');
+    };
+    var deprecatedAPIs = {
+        isMounted: [
+          'isMounted',
+          'Instead, make sure to clean up subscriptions and pending requests in componentWillUnmount to prevent memory leaks.',
+        ],
+        replaceState: [
+          'replaceState',
+          'Refactor your code to use setState instead (see https://github.com/facebook/react/issues/3236).',
+        ],
+      },
+      fnName;
+    for (fnName in deprecatedAPIs)
+      deprecatedAPIs.hasOwnProperty(fnName) &&
+        defineDeprecationWarning(fnName, deprecatedAPIs[fnName]);
+    ComponentDummy.prototype = Component.prototype;
+    deprecatedAPIs = PureComponent.prototype = new ComponentDummy();
+    deprecatedAPIs.constructor = PureComponent;
+    assign(deprecatedAPIs, Component.prototype);
+    deprecatedAPIs.isPureReactComponent = !0;
+    var isArrayImpl = Array.isArray,
+      REACT_CLIENT_REFERENCE$2 = Symbol.for('react.client.reference'),
+      ReactSharedInternals = {
+        H: null,
+        A: null,
+        T: null,
+        S: null,
+        actQueue: null,
+        isBatchingLegacy: !1,
+        didScheduleLegacyUpdate: !1,
+        didUsePromise: !1,
+        thrownErrors: [],
+        getCurrentStack: null,
+      },
+      hasOwnProperty = Object.prototype.hasOwnProperty,
+      REACT_CLIENT_REFERENCE$1 = Symbol.for('react.client.reference'),
+      disabledDepth = 0,
+      prevLog,
+      prevInfo,
+      prevWarn,
+      prevError,
+      prevGroup,
+      prevGroupCollapsed,
+      prevGroupEnd;
+    disabledLog.__reactDisabledLog = !0;
+    var prefix,
+      suffix,
+      reentry = !1;
+    var componentFrameCache = new ('function' === typeof WeakMap ? WeakMap : Map)();
+    var REACT_CLIENT_REFERENCE = Symbol.for('react.client.reference'),
+      specialPropKeyWarningShown,
+      didWarnAboutOldJSXRuntime;
+    var didWarnAboutElementRef = {};
+    var ownerHasKeyUseWarning = {},
+      didWarnAboutMaps = !1,
+      userProvidedKeyEscapeRegex = /\/+/g,
+      reportGlobalError =
+        'function' === typeof reportError
+          ? reportError
+          : function (error) {
+              if ('object' === typeof window && 'function' === typeof window.ErrorEvent) {
+                var event = new window.ErrorEvent('error', {
+                  bubbles: !0,
+                  cancelable: !0,
+                  message:
+                    'object' === typeof error && null !== error && 'string' === typeof error.message
+                      ? String(error.message)
+                      : String(error),
+                  error: error,
+                });
+                if (!window.dispatchEvent(event)) return;
+              } else if ('object' === typeof process && 'function' === typeof process.emit) {
+                process.emit('uncaughtException', error);
+                return;
+              }
+              console.error(error);
+            },
+      didWarnAboutMessageChannel = !1,
+      enqueueTaskImpl = null,
+      actScopeDepth = 0,
+      didWarnNoAwaitAct = !1,
+      isFlushing = !1,
+      queueSeveralMicrotasks =
+        'function' === typeof queueMicrotask
+          ? function (callback) {
+              queueMicrotask(function () {
+                return queueMicrotask(callback);
+              });
+            }
+          : enqueueTask;
+    exports.Children = {
+      map: mapChildren,
+      forEach: function (children, forEachFunc, forEachContext) {
+        mapChildren(
+          children,
+          function () {
+            forEachFunc.apply(this, arguments);
+          },
+          forEachContext,
+        );
+      },
+      count: function (children) {
+        var n = 0;
+        mapChildren(children, function () {
+          n++;
+        });
+        return n;
+      },
+      toArray: function (children) {
+        return (
+          mapChildren(children, function (child) {
+            return child;
+          }) || []
+        );
+      },
+      only: function (children) {
+        if (!isValidElement(children))
+          throw Error('React.Children.only expected to receive a single React element child.');
+        return children;
+      },
+    };
+    exports.Component = Component;
+    exports.Fragment = REACT_FRAGMENT_TYPE;
+    exports.Profiler = REACT_PROFILER_TYPE;
+    exports.PureComponent = PureComponent;
+    exports.StrictMode = REACT_STRICT_MODE_TYPE;
+    exports.Suspense = REACT_SUSPENSE_TYPE;
+    exports.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = ReactSharedInternals;
+    exports.act = function (callback) {
+      var prevActQueue = ReactSharedInternals.actQueue,
+        prevActScopeDepth = actScopeDepth;
+      actScopeDepth++;
+      var queue = (ReactSharedInternals.actQueue = null !== prevActQueue ? prevActQueue : []),
+        didAwaitActCall = !1;
+      try {
+        var result = callback();
+      } catch (error) {
+        ReactSharedInternals.thrownErrors.push(error);
+      }
+      if (0 < ReactSharedInternals.thrownErrors.length)
+        throw (
+          (popActScope(prevActQueue, prevActScopeDepth),
+          (callback = aggregateErrors(ReactSharedInternals.thrownErrors)),
+          (ReactSharedInternals.thrownErrors.length = 0),
+          callback)
+        );
+      if (null !== result && 'object' === typeof result && 'function' === typeof result.then) {
+        var thenable = result;
+        queueSeveralMicrotasks(function () {
+          didAwaitActCall ||
+            didWarnNoAwaitAct ||
+            ((didWarnNoAwaitAct = !0),
+            console.error(
+              'You called act(async () => ...) without await. This could lead to unexpected testing behaviour, interleaving multiple act calls and mixing their scopes. You should - await act(async () => ...);',
+            ));
+        });
+        return {
+          then: function (resolve, reject) {
+            didAwaitActCall = !0;
+            thenable.then(
+              function (returnValue) {
+                popActScope(prevActQueue, prevActScopeDepth);
+                if (0 === prevActScopeDepth) {
+                  try {
+                    flushActQueue(queue),
+                      enqueueTask(function () {
+                        return recursivelyFlushAsyncActWork(returnValue, resolve, reject);
+                      });
+                  } catch (error$2) {
+                    ReactSharedInternals.thrownErrors.push(error$2);
+                  }
+                  if (0 < ReactSharedInternals.thrownErrors.length) {
+                    var _thrownError = aggregateErrors(ReactSharedInternals.thrownErrors);
+                    ReactSharedInternals.thrownErrors.length = 0;
+                    reject(_thrownError);
+                  }
+                } else resolve(returnValue);
+              },
+              function (error) {
+                popActScope(prevActQueue, prevActScopeDepth);
+                0 < ReactSharedInternals.thrownErrors.length
+                  ? ((error = aggregateErrors(ReactSharedInternals.thrownErrors)),
+                    (ReactSharedInternals.thrownErrors.length = 0),
+                    reject(error))
+                  : reject(error);
+              },
+            );
+          },
+        };
+      }
+      var returnValue$jscomp$0 = result;
+      popActScope(prevActQueue, prevActScopeDepth);
+      0 === prevActScopeDepth &&
+        (flushActQueue(queue),
+        0 !== queue.length &&
+          queueSeveralMicrotasks(function () {
+            didAwaitActCall ||
+              didWarnNoAwaitAct ||
+              ((didWarnNoAwaitAct = !0),
+              console.error(
+                'A component suspended inside an `act` scope, but the `act` call was not awaited. When testing React components that depend on asynchronous data, you must await the result:\n\nawait act(() => ...)',
+              ));
+          }),
+        (ReactSharedInternals.actQueue = null));
+      if (0 < ReactSharedInternals.thrownErrors.length)
+        throw (
+          ((callback = aggregateErrors(ReactSharedInternals.thrownErrors)),
+          (ReactSharedInternals.thrownErrors.length = 0),
+          callback)
+        );
+      return {
+        then: function (resolve, reject) {
+          didAwaitActCall = !0;
+          0 === prevActScopeDepth
+            ? ((ReactSharedInternals.actQueue = queue),
+              enqueueTask(function () {
+                return recursivelyFlushAsyncActWork(returnValue$jscomp$0, resolve, reject);
+              }))
+            : resolve(returnValue$jscomp$0);
+        },
+      };
+    };
+    exports.cache = function (fn) {
+      return function () {
+        return fn.apply(null, arguments);
+      };
+    };
+    exports.cloneElement = function (element, config, children) {
+      if (null === element || void 0 === element)
+        throw Error('The argument must be a React element, but you passed ' + element + '.');
+      var props = assign({}, element.props),
+        key = element.key,
+        owner = element._owner;
+      if (null != config) {
+        var JSCompiler_inline_result;
+        a: {
+          if (
+            hasOwnProperty.call(config, 'ref') &&
+            (JSCompiler_inline_result = Object.getOwnPropertyDescriptor(config, 'ref').get) &&
+            JSCompiler_inline_result.isReactWarning
+          ) {
+            JSCompiler_inline_result = !1;
+            break a;
+          }
+          JSCompiler_inline_result = void 0 !== config.ref;
+        }
+        JSCompiler_inline_result && (owner = getOwner());
+        hasValidKey(config) && (checkKeyStringCoercion(config.key), (key = '' + config.key));
+        for (propName in config)
+          !hasOwnProperty.call(config, propName) ||
+            'key' === propName ||
+            '__self' === propName ||
+            '__source' === propName ||
+            ('ref' === propName && void 0 === config.ref) ||
+            (props[propName] = config[propName]);
+      }
+      var propName = arguments.length - 2;
+      if (1 === propName) props.children = children;
+      else if (1 < propName) {
+        JSCompiler_inline_result = Array(propName);
+        for (var i = 0; i < propName; i++) JSCompiler_inline_result[i] = arguments[i + 2];
+        props.children = JSCompiler_inline_result;
+      }
+      props = ReactElement(element.type, key, void 0, void 0, owner, props);
+      for (key = 2; key < arguments.length; key++) validateChildKeys(arguments[key], props.type);
+      return props;
+    };
+    exports.createContext = function (defaultValue) {
+      defaultValue = {
+        $$typeof: REACT_CONTEXT_TYPE,
+        _currentValue: defaultValue,
+        _currentValue2: defaultValue,
+        _threadCount: 0,
+        Provider: null,
+        Consumer: null,
+      };
+      defaultValue.Provider = defaultValue;
+      defaultValue.Consumer = {
+        $$typeof: REACT_CONSUMER_TYPE,
+        _context: defaultValue,
+      };
+      defaultValue._currentRenderer = null;
+      defaultValue._currentRenderer2 = null;
+      return defaultValue;
+    };
+    exports.createElement = function (type, config, children) {
+      if (isValidElementType(type))
+        for (var i = 2; i < arguments.length; i++) validateChildKeys(arguments[i], type);
+      else {
+        i = '';
+        if (
+          void 0 === type ||
+          ('object' === typeof type && null !== type && 0 === Object.keys(type).length)
+        )
+          i +=
+            " You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.";
+        if (null === type) var typeString = 'null';
+        else
+          isArrayImpl(type)
+            ? (typeString = 'array')
+            : void 0 !== type && type.$$typeof === REACT_ELEMENT_TYPE
+            ? ((typeString = '<' + (getComponentNameFromType(type.type) || 'Unknown') + ' />'),
+              (i = ' Did you accidentally export a JSX literal instead of a component?'))
+            : (typeString = typeof type);
+        console.error(
+          'React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s',
+          typeString,
+          i,
+        );
+      }
+      var propName;
+      i = {};
+      typeString = null;
+      if (null != config)
+        for (propName in (didWarnAboutOldJSXRuntime ||
+          !('__self' in config) ||
+          'key' in config ||
+          ((didWarnAboutOldJSXRuntime = !0),
+          console.warn(
+            'Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform',
+          )),
+        hasValidKey(config) && (checkKeyStringCoercion(config.key), (typeString = '' + config.key)),
+        config))
+          hasOwnProperty.call(config, propName) &&
+            'key' !== propName &&
+            '__self' !== propName &&
+            '__source' !== propName &&
+            (i[propName] = config[propName]);
+      var childrenLength = arguments.length - 2;
+      if (1 === childrenLength) i.children = children;
+      else if (1 < childrenLength) {
+        for (var childArray = Array(childrenLength), _i = 0; _i < childrenLength; _i++)
+          childArray[_i] = arguments[_i + 2];
+        Object.freeze && Object.freeze(childArray);
+        i.children = childArray;
+      }
+      if (type && type.defaultProps)
+        for (propName in ((childrenLength = type.defaultProps), childrenLength))
+          void 0 === i[propName] && (i[propName] = childrenLength[propName]);
+      typeString &&
+        defineKeyPropWarningGetter(
+          i,
+          'function' === typeof type ? type.displayName || type.name || 'Unknown' : type,
+        );
+      return ReactElement(type, typeString, void 0, void 0, getOwner(), i);
+    };
+    exports.createRef = function () {
+      var refObject = { current: null };
+      Object.seal(refObject);
+      return refObject;
+    };
+    exports.forwardRef = function (render) {
+      null != render && render.$$typeof === REACT_MEMO_TYPE
+        ? console.error(
+            'forwardRef requires a render function but received a `memo` component. Instead of forwardRef(memo(...)), use memo(forwardRef(...)).',
+          )
+        : 'function' !== typeof render
+        ? console.error(
+            'forwardRef requires a render function but was given %s.',
+            null === render ? 'null' : typeof render,
+          )
+        : 0 !== render.length &&
+          2 !== render.length &&
+          console.error(
+            'forwardRef render functions accept exactly two parameters: props and ref. %s',
+            1 === render.length
+              ? 'Did you forget to use the ref parameter?'
+              : 'Any additional parameter will be undefined.',
+          );
+      null != render &&
+        null != render.defaultProps &&
+        console.error(
+          'forwardRef render functions do not support defaultProps. Did you accidentally pass a React component?',
+        );
+      var elementType = { $$typeof: REACT_FORWARD_REF_TYPE, render: render },
+        ownName;
+      Object.defineProperty(elementType, 'displayName', {
+        enumerable: !1,
+        configurable: !0,
+        get: function () {
+          return ownName;
+        },
+        set: function (name) {
+          ownName = name;
+          render.name ||
+            render.displayName ||
+            (Object.defineProperty(render, 'name', { value: name }), (render.displayName = name));
+        },
+      });
+      return elementType;
+    };
+    exports.isValidElement = isValidElement;
+    exports.lazy = function (ctor) {
+      return {
+        $$typeof: REACT_LAZY_TYPE,
+        _payload: { _status: -1, _result: ctor },
+        _init: lazyInitializer,
+      };
+    };
+    exports.memo = function (type, compare) {
+      isValidElementType(type) ||
+        console.error(
+          'memo: The first argument must be a component. Instead received: %s',
+          null === type ? 'null' : typeof type,
+        );
+      compare = {
+        $$typeof: REACT_MEMO_TYPE,
+        type: type,
+        compare: void 0 === compare ? null : compare,
+      };
+      var ownName;
+      Object.defineProperty(compare, 'displayName', {
+        enumerable: !1,
+        configurable: !0,
+        get: function () {
+          return ownName;
+        },
+        set: function (name) {
+          ownName = name;
+          type.name ||
+            type.displayName ||
+            (Object.defineProperty(type, 'name', { value: name }), (type.displayName = name));
+        },
+      });
+      return compare;
+    };
+    exports.startTransition = function (scope) {
+      var prevTransition = ReactSharedInternals.T,
+        currentTransition = {};
+      ReactSharedInternals.T = currentTransition;
+      currentTransition._updatedFibers = new Set();
+      try {
+        var returnValue = scope(),
+          onStartTransitionFinish = ReactSharedInternals.S;
+        null !== onStartTransitionFinish && onStartTransitionFinish(currentTransition, returnValue);
+        'object' === typeof returnValue &&
+          null !== returnValue &&
+          'function' === typeof returnValue.then &&
+          returnValue.then(noop, reportGlobalError);
+      } catch (error) {
+        reportGlobalError(error);
+      } finally {
+        null === prevTransition &&
+          currentTransition._updatedFibers &&
+          ((scope = currentTransition._updatedFibers.size),
+          currentTransition._updatedFibers.clear(),
+          10 < scope &&
+            console.warn(
+              'Detected a large number of updates inside startTransition. If this is due to a subscription please re-write it to use React provided hooks. Otherwise concurrent mode guarantees are off the table.',
+            )),
+          (ReactSharedInternals.T = prevTransition);
+      }
+    };
+    exports.unstable_useCacheRefresh = function () {
+      return resolveDispatcher().useCacheRefresh();
+    };
+    exports.use = function (usable) {
+      return resolveDispatcher().use(usable);
+    };
+    exports.useActionState = function (action, initialState, permalink) {
+      return resolveDispatcher().useActionState(action, initialState, permalink);
+    };
+    exports.useCallback = function (callback, deps) {
+      return resolveDispatcher().useCallback(callback, deps);
+    };
+    exports.useContext = function (Context) {
+      var dispatcher = resolveDispatcher();
+      Context.$$typeof === REACT_CONSUMER_TYPE &&
+        console.error(
+          'Calling useContext(Context.Consumer) is not supported and will cause bugs. Did you mean to call useContext(Context) instead?',
+        );
+      return dispatcher.useContext(Context);
+    };
+    exports.useDebugValue = function (value, formatterFn) {
+      return resolveDispatcher().useDebugValue(value, formatterFn);
+    };
+    exports.useDeferredValue = function (value, initialValue) {
+      return resolveDispatcher().useDeferredValue(value, initialValue);
+    };
+    exports.useEffect = function (create, deps) {
+      return resolveDispatcher().useEffect(create, deps);
+    };
+    exports.useId = function () {
+      return resolveDispatcher().useId();
+    };
+    exports.useImperativeHandle = function (ref, create, deps) {
+      return resolveDispatcher().useImperativeHandle(ref, create, deps);
+    };
+    exports.useInsertionEffect = function (create, deps) {
+      return resolveDispatcher().useInsertionEffect(create, deps);
+    };
+    exports.useLayoutEffect = function (create, deps) {
+      return resolveDispatcher().useLayoutEffect(create, deps);
+    };
+    exports.useMemo = function (create, deps) {
+      return resolveDispatcher().useMemo(create, deps);
+    };
+    exports.useOptimistic = function (passthrough, reducer) {
+      return resolveDispatcher().useOptimistic(passthrough, reducer);
+    };
+    exports.useReducer = function (reducer, initialArg, init) {
+      return resolveDispatcher().useReducer(reducer, initialArg, init);
+    };
+    exports.useRef = function (initialValue) {
+      return resolveDispatcher().useRef(initialValue);
+    };
+    exports.useState = function (initialState) {
+      return resolveDispatcher().useState(initialState);
+    };
+    exports.useSyncExternalStore = function (subscribe, getSnapshot, getServerSnapshot) {
+      return resolveDispatcher().useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+    };
+    exports.useTransition = function () {
+      return resolveDispatcher().useTransition();
+    };
+    exports.version = '19.0.0';
+    'undefined' !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ &&
+      'function' === typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop &&
+      __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(Error());
+  })();

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/options.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/options.js
@@ -1,0 +1,10 @@
+import * as path from 'path';
+
+module.exports = {
+  babelOptions: {
+    filename: path.join(
+      __dirname,
+      'ReactNativeNewArch/node_modules/react/cjs/react.development.js',
+    ),
+  },
+};

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
@@ -1,0 +1,1450 @@
+/**
+ * @license React
+ * react.development.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { applyFSPropertiesWithRef } = require('@fullstory/react-native/src');
+('use strict');
+'production' !== process.env.NODE_ENV &&
+  (function () {
+    function defineDeprecationWarning(methodName, info) {
+      Object.defineProperty(Component.prototype, methodName, {
+        get: function () {
+          console.warn(
+            '%s(...) is deprecated in plain JavaScript React classes. %s',
+            info[0],
+            info[1],
+          );
+        },
+      });
+    }
+    function getIteratorFn(maybeIterable) {
+      if (null === maybeIterable || 'object' !== typeof maybeIterable) return null;
+      maybeIterable =
+        (MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL]) ||
+        maybeIterable['@@iterator'];
+      return 'function' === typeof maybeIterable ? maybeIterable : null;
+    }
+    function warnNoop(publicInstance, callerName) {
+      publicInstance =
+        ((publicInstance = publicInstance.constructor) &&
+          (publicInstance.displayName || publicInstance.name)) ||
+        'ReactClass';
+      var warningKey = publicInstance + '.' + callerName;
+      didWarnStateUpdateForUnmountedComponent[warningKey] ||
+        (console.error(
+          "Can't call %s on a component that is not yet mounted. This is a no-op, but it might indicate a bug in your application. Instead, assign to `this.state` directly or define a `state = {};` class property with the desired state in the %s component.",
+          callerName,
+          publicInstance,
+        ),
+        (didWarnStateUpdateForUnmountedComponent[warningKey] = !0));
+    }
+    function Component(props, context, updater) {
+      this.props = props;
+      this.context = context;
+      this.refs = emptyObject;
+      this.updater = updater || ReactNoopUpdateQueue;
+    }
+    function ComponentDummy() {}
+    function PureComponent(props, context, updater) {
+      this.props = props;
+      this.context = context;
+      this.refs = emptyObject;
+      this.updater = updater || ReactNoopUpdateQueue;
+    }
+    function testStringCoercion(value) {
+      return '' + value;
+    }
+    function checkKeyStringCoercion(value) {
+      try {
+        testStringCoercion(value);
+        var JSCompiler_inline_result = !1;
+      } catch (e) {
+        JSCompiler_inline_result = !0;
+      }
+      if (JSCompiler_inline_result) {
+        JSCompiler_inline_result = console;
+        var JSCompiler_temp_const = JSCompiler_inline_result.error;
+        var JSCompiler_inline_result$jscomp$0 =
+          ('function' === typeof Symbol && Symbol.toStringTag && value[Symbol.toStringTag]) ||
+          value.constructor.name ||
+          'Object';
+        JSCompiler_temp_const.call(
+          JSCompiler_inline_result,
+          'The provided key is an unsupported type %s. This value must be coerced to a string before using it here.',
+          JSCompiler_inline_result$jscomp$0,
+        );
+        return testStringCoercion(value);
+      }
+    }
+    function getComponentNameFromType(type) {
+      if (null == type) return null;
+      if ('function' === typeof type)
+        return type.$$typeof === REACT_CLIENT_REFERENCE$2
+          ? null
+          : type.displayName || type.name || null;
+      if ('string' === typeof type) return type;
+      switch (type) {
+        case REACT_FRAGMENT_TYPE:
+          return 'Fragment';
+        case REACT_PORTAL_TYPE:
+          return 'Portal';
+        case REACT_PROFILER_TYPE:
+          return 'Profiler';
+        case REACT_STRICT_MODE_TYPE:
+          return 'StrictMode';
+        case REACT_SUSPENSE_TYPE:
+          return 'Suspense';
+        case REACT_SUSPENSE_LIST_TYPE:
+          return 'SuspenseList';
+      }
+      if ('object' === typeof type)
+        switch (
+          ('number' === typeof type.tag &&
+            console.error(
+              'Received an unexpected object in getComponentNameFromType(). This is likely a bug in React. Please file an issue.',
+            ),
+          type.$$typeof)
+        ) {
+          case REACT_CONTEXT_TYPE:
+            return (type.displayName || 'Context') + '.Provider';
+          case REACT_CONSUMER_TYPE:
+            return (type._context.displayName || 'Context') + '.Consumer';
+          case REACT_FORWARD_REF_TYPE:
+            var innerType = type.render;
+            type = type.displayName;
+            type ||
+              ((type = innerType.displayName || innerType.name || ''),
+              (type = '' !== type ? 'ForwardRef(' + type + ')' : 'ForwardRef'));
+            return type;
+          case REACT_MEMO_TYPE:
+            return (
+              (innerType = type.displayName || null),
+              null !== innerType ? innerType : getComponentNameFromType(type.type) || 'Memo'
+            );
+          case REACT_LAZY_TYPE:
+            innerType = type._payload;
+            type = type._init;
+            try {
+              return getComponentNameFromType(type(innerType));
+            } catch (x) {}
+        }
+      return null;
+    }
+    function isValidElementType(type) {
+      return 'string' === typeof type ||
+        'function' === typeof type ||
+        type === REACT_FRAGMENT_TYPE ||
+        type === REACT_PROFILER_TYPE ||
+        type === REACT_STRICT_MODE_TYPE ||
+        type === REACT_SUSPENSE_TYPE ||
+        type === REACT_SUSPENSE_LIST_TYPE ||
+        type === REACT_OFFSCREEN_TYPE ||
+        ('object' === typeof type &&
+          null !== type &&
+          (type.$$typeof === REACT_LAZY_TYPE ||
+            type.$$typeof === REACT_MEMO_TYPE ||
+            type.$$typeof === REACT_CONTEXT_TYPE ||
+            type.$$typeof === REACT_CONSUMER_TYPE ||
+            type.$$typeof === REACT_FORWARD_REF_TYPE ||
+            type.$$typeof === REACT_CLIENT_REFERENCE$1 ||
+            void 0 !== type.getModuleId))
+        ? !0
+        : !1;
+    }
+    function disabledLog() {}
+    function disableLogs() {
+      if (0 === disabledDepth) {
+        prevLog = console.log;
+        prevInfo = console.info;
+        prevWarn = console.warn;
+        prevError = console.error;
+        prevGroup = console.group;
+        prevGroupCollapsed = console.groupCollapsed;
+        prevGroupEnd = console.groupEnd;
+        var props = {
+          configurable: !0,
+          enumerable: !0,
+          value: disabledLog,
+          writable: !0,
+        };
+        Object.defineProperties(console, {
+          info: props,
+          log: props,
+          warn: props,
+          error: props,
+          group: props,
+          groupCollapsed: props,
+          groupEnd: props,
+        });
+      }
+      disabledDepth++;
+    }
+    function reenableLogs() {
+      disabledDepth--;
+      if (0 === disabledDepth) {
+        var props = {
+          configurable: !0,
+          enumerable: !0,
+          writable: !0,
+        };
+        Object.defineProperties(console, {
+          log: assign({}, props, {
+            value: prevLog,
+          }),
+          info: assign({}, props, {
+            value: prevInfo,
+          }),
+          warn: assign({}, props, {
+            value: prevWarn,
+          }),
+          error: assign({}, props, {
+            value: prevError,
+          }),
+          group: assign({}, props, {
+            value: prevGroup,
+          }),
+          groupCollapsed: assign({}, props, {
+            value: prevGroupCollapsed,
+          }),
+          groupEnd: assign({}, props, {
+            value: prevGroupEnd,
+          }),
+        });
+      }
+      0 > disabledDepth &&
+        console.error(
+          'disabledDepth fell below zero. This is a bug in React. Please file an issue.',
+        );
+    }
+    function describeBuiltInComponentFrame(name) {
+      if (void 0 === prefix)
+        try {
+          throw Error();
+        } catch (x) {
+          var match = x.stack.trim().match(/\n( *(at )?)/);
+          prefix = (match && match[1]) || '';
+          suffix =
+            -1 < x.stack.indexOf('\n    at')
+              ? ' (<anonymous>)'
+              : -1 < x.stack.indexOf('@')
+              ? '@unknown:0:0'
+              : '';
+        }
+      return '\n' + prefix + name + suffix;
+    }
+    function describeNativeComponentFrame(fn, construct) {
+      if (!fn || reentry) return '';
+      var frame = componentFrameCache.get(fn);
+      if (void 0 !== frame) return frame;
+      reentry = !0;
+      frame = Error.prepareStackTrace;
+      Error.prepareStackTrace = void 0;
+      var previousDispatcher = null;
+      previousDispatcher = ReactSharedInternals.H;
+      ReactSharedInternals.H = null;
+      disableLogs();
+      try {
+        var RunInRootFrame = {
+          DetermineComponentFrameRoot: function () {
+            try {
+              if (construct) {
+                var Fake = function () {
+                  throw Error();
+                };
+                Object.defineProperty(Fake.prototype, 'props', {
+                  set: function () {
+                    throw Error();
+                  },
+                });
+                if ('object' === typeof Reflect && Reflect.construct) {
+                  try {
+                    Reflect.construct(Fake, []);
+                  } catch (x) {
+                    var control = x;
+                  }
+                  Reflect.construct(fn, [], Fake);
+                } else {
+                  try {
+                    Fake.call();
+                  } catch (x$0) {
+                    control = x$0;
+                  }
+                  fn.call(Fake.prototype);
+                }
+              } else {
+                try {
+                  throw Error();
+                } catch (x$1) {
+                  control = x$1;
+                }
+                (Fake = fn()) && 'function' === typeof Fake.catch && Fake.catch(function () {});
+              }
+            } catch (sample) {
+              if (sample && control && 'string' === typeof sample.stack)
+                return [sample.stack, control.stack];
+            }
+            return [null, null];
+          },
+        };
+        RunInRootFrame.DetermineComponentFrameRoot.displayName = 'DetermineComponentFrameRoot';
+        var namePropDescriptor = Object.getOwnPropertyDescriptor(
+          RunInRootFrame.DetermineComponentFrameRoot,
+          'name',
+        );
+        namePropDescriptor &&
+          namePropDescriptor.configurable &&
+          Object.defineProperty(RunInRootFrame.DetermineComponentFrameRoot, 'name', {
+            value: 'DetermineComponentFrameRoot',
+          });
+        var _RunInRootFrame$Deter = RunInRootFrame.DetermineComponentFrameRoot(),
+          sampleStack = _RunInRootFrame$Deter[0],
+          controlStack = _RunInRootFrame$Deter[1];
+        if (sampleStack && controlStack) {
+          var sampleLines = sampleStack.split('\n'),
+            controlLines = controlStack.split('\n');
+          for (
+            _RunInRootFrame$Deter = namePropDescriptor = 0;
+            namePropDescriptor < sampleLines.length &&
+            !sampleLines[namePropDescriptor].includes('DetermineComponentFrameRoot');
+
+          )
+            namePropDescriptor++;
+          for (
+            ;
+            _RunInRootFrame$Deter < controlLines.length &&
+            !controlLines[_RunInRootFrame$Deter].includes('DetermineComponentFrameRoot');
+
+          )
+            _RunInRootFrame$Deter++;
+          if (
+            namePropDescriptor === sampleLines.length ||
+            _RunInRootFrame$Deter === controlLines.length
+          )
+            for (
+              namePropDescriptor = sampleLines.length - 1,
+                _RunInRootFrame$Deter = controlLines.length - 1;
+              1 <= namePropDescriptor &&
+              0 <= _RunInRootFrame$Deter &&
+              sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter];
+
+            )
+              _RunInRootFrame$Deter--;
+          for (
+            ;
+            1 <= namePropDescriptor && 0 <= _RunInRootFrame$Deter;
+            namePropDescriptor--, _RunInRootFrame$Deter--
+          )
+            if (sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter]) {
+              if (1 !== namePropDescriptor || 1 !== _RunInRootFrame$Deter) {
+                do
+                  if (
+                    (namePropDescriptor--,
+                    _RunInRootFrame$Deter--,
+                    0 > _RunInRootFrame$Deter ||
+                      sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter])
+                  ) {
+                    var _frame = '\n' + sampleLines[namePropDescriptor].replace(' at new ', ' at ');
+                    fn.displayName &&
+                      _frame.includes('<anonymous>') &&
+                      (_frame = _frame.replace('<anonymous>', fn.displayName));
+                    'function' === typeof fn && componentFrameCache.set(fn, _frame);
+                    return _frame;
+                  }
+                while (1 <= namePropDescriptor && 0 <= _RunInRootFrame$Deter);
+              }
+              break;
+            }
+        }
+      } finally {
+        (reentry = !1),
+          (ReactSharedInternals.H = previousDispatcher),
+          reenableLogs(),
+          (Error.prepareStackTrace = frame);
+      }
+      sampleLines = (sampleLines = fn ? fn.displayName || fn.name : '')
+        ? describeBuiltInComponentFrame(sampleLines)
+        : '';
+      'function' === typeof fn && componentFrameCache.set(fn, sampleLines);
+      return sampleLines;
+    }
+    function describeUnknownElementTypeFrameInDEV(type) {
+      if (null == type) return '';
+      if ('function' === typeof type) {
+        var prototype = type.prototype;
+        return describeNativeComponentFrame(type, !(!prototype || !prototype.isReactComponent));
+      }
+      if ('string' === typeof type) return describeBuiltInComponentFrame(type);
+      switch (type) {
+        case REACT_SUSPENSE_TYPE:
+          return describeBuiltInComponentFrame('Suspense');
+        case REACT_SUSPENSE_LIST_TYPE:
+          return describeBuiltInComponentFrame('SuspenseList');
+      }
+      if ('object' === typeof type)
+        switch (type.$$typeof) {
+          case REACT_FORWARD_REF_TYPE:
+            return (type = describeNativeComponentFrame(type.render, !1)), type;
+          case REACT_MEMO_TYPE:
+            return describeUnknownElementTypeFrameInDEV(type.type);
+          case REACT_LAZY_TYPE:
+            prototype = type._payload;
+            type = type._init;
+            try {
+              return describeUnknownElementTypeFrameInDEV(type(prototype));
+            } catch (x) {}
+        }
+      return '';
+    }
+    function getOwner() {
+      var dispatcher = ReactSharedInternals.A;
+      return null === dispatcher ? null : dispatcher.getOwner();
+    }
+    function hasValidKey(config) {
+      if (hasOwnProperty.call(config, 'key')) {
+        var getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+        if (getter && getter.isReactWarning) return !1;
+      }
+      return void 0 !== config.key;
+    }
+    function defineKeyPropWarningGetter(props, displayName) {
+      function warnAboutAccessingKey() {
+        specialPropKeyWarningShown ||
+          ((specialPropKeyWarningShown = !0),
+          console.error(
+            '%s: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://react.dev/link/special-props)',
+            displayName,
+          ));
+      }
+      warnAboutAccessingKey.isReactWarning = !0;
+      Object.defineProperty(props, 'key', {
+        get: warnAboutAccessingKey,
+        configurable: !0,
+      });
+    }
+    function elementRefGetterWithDeprecationWarning() {
+      var componentName = getComponentNameFromType(this.type);
+      didWarnAboutElementRef[componentName] ||
+        ((didWarnAboutElementRef[componentName] = !0),
+        console.error(
+          'Accessing element.ref was removed in React 19. ref is now a regular prop. It will be removed from the JSX Element type in a future release.',
+        ));
+      componentName = this.props.ref;
+      return void 0 !== componentName ? componentName : null;
+    }
+    function ReactElement(type, key, self, source, owner, props) {
+      props = {
+        ...props,
+        ref: applyFSPropertiesWithRef(props.ref),
+      };
+      self = props.ref;
+      const { Platform } = require('react-native');
+      const SUPPORTED_FS_ATTRIBUTES = [
+        'fsClass',
+        'fsAttribute',
+        'fsTagName',
+        'dataElement',
+        'dataComponent',
+        'dataSourceFile',
+      ];
+      const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+      if (isTurboModuleEnabled && Platform.OS === 'ios') {
+        if (
+          type.$$typeof &&
+          (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
+            type.$$typeof.toString() === 'Symbol(react.element)' ||
+            type.$$typeof.toString() === 'Symbol(react.transitional.element)')
+        ) {
+          if (props) {
+            const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+              return typeof props[fsAttribute] === 'string' && !!props[fsAttribute];
+            });
+            if (propContainsFSAttribute) {
+              const fs = require('@fullstory/react-native');
+              props = {
+                ...props,
+                ref: fs.applyFSPropertiesWithRef(props['ref']),
+              };
+            }
+          }
+        }
+      }
+      type = {
+        $$typeof: REACT_ELEMENT_TYPE,
+        type: type,
+        key: key,
+        props: props,
+        _owner: owner,
+      };
+      null !== (void 0 !== self ? self : null)
+        ? Object.defineProperty(type, 'ref', {
+            enumerable: !1,
+            get: elementRefGetterWithDeprecationWarning,
+          })
+        : Object.defineProperty(type, 'ref', {
+            enumerable: !1,
+            value: null,
+          });
+      type._store = {};
+      Object.defineProperty(type._store, 'validated', {
+        configurable: !1,
+        enumerable: !1,
+        writable: !0,
+        value: 0,
+      });
+      Object.defineProperty(type, '_debugInfo', {
+        configurable: !1,
+        enumerable: !1,
+        writable: !0,
+        value: null,
+      });
+      Object.freeze && (Object.freeze(type.props), Object.freeze(type));
+      return type;
+    }
+    function cloneAndReplaceKey(oldElement, newKey) {
+      newKey = ReactElement(
+        oldElement.type,
+        newKey,
+        void 0,
+        void 0,
+        oldElement._owner,
+        oldElement.props,
+      );
+      newKey._store.validated = oldElement._store.validated;
+      return newKey;
+    }
+    function validateChildKeys(node, parentType) {
+      if ('object' === typeof node && node && node.$$typeof !== REACT_CLIENT_REFERENCE)
+        if (isArrayImpl(node))
+          for (var i = 0; i < node.length; i++) {
+            var child = node[i];
+            isValidElement(child) && validateExplicitKey(child, parentType);
+          }
+        else if (isValidElement(node)) node._store && (node._store.validated = 1);
+        else if (
+          ((i = getIteratorFn(node)),
+          'function' === typeof i && i !== node.entries && ((i = i.call(node)), i !== node))
+        )
+          for (; !(node = i.next()).done; )
+            isValidElement(node.value) && validateExplicitKey(node.value, parentType);
+    }
+    function isValidElement(object) {
+      return (
+        'object' === typeof object && null !== object && object.$$typeof === REACT_ELEMENT_TYPE
+      );
+    }
+    function validateExplicitKey(element, parentType) {
+      if (
+        element._store &&
+        !element._store.validated &&
+        null == element.key &&
+        ((element._store.validated = 1),
+        (parentType = getCurrentComponentErrorInfo(parentType)),
+        !ownerHasKeyUseWarning[parentType])
+      ) {
+        ownerHasKeyUseWarning[parentType] = !0;
+        var childOwner = '';
+        element &&
+          null != element._owner &&
+          element._owner !== getOwner() &&
+          ((childOwner = null),
+          'number' === typeof element._owner.tag
+            ? (childOwner = getComponentNameFromType(element._owner.type))
+            : 'string' === typeof element._owner.name && (childOwner = element._owner.name),
+          (childOwner = ' It was passed a child from ' + childOwner + '.'));
+        var prevGetCurrentStack = ReactSharedInternals.getCurrentStack;
+        ReactSharedInternals.getCurrentStack = function () {
+          var stack = describeUnknownElementTypeFrameInDEV(element.type);
+          prevGetCurrentStack && (stack += prevGetCurrentStack() || '');
+          return stack;
+        };
+        console.error(
+          'Each child in a list should have a unique "key" prop.%s%s See https://react.dev/link/warning-keys for more information.',
+          parentType,
+          childOwner,
+        );
+        ReactSharedInternals.getCurrentStack = prevGetCurrentStack;
+      }
+    }
+    function getCurrentComponentErrorInfo(parentType) {
+      var info = '',
+        owner = getOwner();
+      owner &&
+        (owner = getComponentNameFromType(owner.type)) &&
+        (info = '\n\nCheck the render method of `' + owner + '`.');
+      info ||
+        ((parentType = getComponentNameFromType(parentType)) &&
+          (info = '\n\nCheck the top-level render call using <' + parentType + '>.'));
+      return info;
+    }
+    function escape(key) {
+      var escaperLookup = {
+        '=': '=0',
+        ':': '=2',
+      };
+      return (
+        '$' +
+        key.replace(/[=:]/g, function (match) {
+          return escaperLookup[match];
+        })
+      );
+    }
+    function getElementKey(element, index) {
+      return 'object' === typeof element && null !== element && null != element.key
+        ? (checkKeyStringCoercion(element.key), escape('' + element.key))
+        : index.toString(36);
+    }
+    function noop$1() {}
+    function resolveThenable(thenable) {
+      switch (thenable.status) {
+        case 'fulfilled':
+          return thenable.value;
+        case 'rejected':
+          throw thenable.reason;
+        default:
+          switch (
+            ('string' === typeof thenable.status
+              ? thenable.then(noop$1, noop$1)
+              : ((thenable.status = 'pending'),
+                thenable.then(
+                  function (fulfilledValue) {
+                    'pending' === thenable.status &&
+                      ((thenable.status = 'fulfilled'), (thenable.value = fulfilledValue));
+                  },
+                  function (error) {
+                    'pending' === thenable.status &&
+                      ((thenable.status = 'rejected'), (thenable.reason = error));
+                  },
+                )),
+            thenable.status)
+          ) {
+            case 'fulfilled':
+              return thenable.value;
+            case 'rejected':
+              throw thenable.reason;
+          }
+      }
+      throw thenable;
+    }
+    function mapIntoArray(children, array, escapedPrefix, nameSoFar, callback) {
+      var type = typeof children;
+      if ('undefined' === type || 'boolean' === type) children = null;
+      var invokeCallback = !1;
+      if (null === children) invokeCallback = !0;
+      else
+        switch (type) {
+          case 'bigint':
+          case 'string':
+          case 'number':
+            invokeCallback = !0;
+            break;
+          case 'object':
+            switch (children.$$typeof) {
+              case REACT_ELEMENT_TYPE:
+              case REACT_PORTAL_TYPE:
+                invokeCallback = !0;
+                break;
+              case REACT_LAZY_TYPE:
+                return (
+                  (invokeCallback = children._init),
+                  mapIntoArray(
+                    invokeCallback(children._payload),
+                    array,
+                    escapedPrefix,
+                    nameSoFar,
+                    callback,
+                  )
+                );
+            }
+        }
+      if (invokeCallback) {
+        invokeCallback = children;
+        callback = callback(invokeCallback);
+        var childKey = '' === nameSoFar ? '.' + getElementKey(invokeCallback, 0) : nameSoFar;
+        isArrayImpl(callback)
+          ? ((escapedPrefix = ''),
+            null != childKey &&
+              (escapedPrefix = childKey.replace(userProvidedKeyEscapeRegex, '$&/') + '/'),
+            mapIntoArray(callback, array, escapedPrefix, '', function (c) {
+              return c;
+            }))
+          : null != callback &&
+            (isValidElement(callback) &&
+              (null != callback.key &&
+                ((invokeCallback && invokeCallback.key === callback.key) ||
+                  checkKeyStringCoercion(callback.key)),
+              (escapedPrefix = cloneAndReplaceKey(
+                callback,
+                escapedPrefix +
+                  (null == callback.key || (invokeCallback && invokeCallback.key === callback.key)
+                    ? ''
+                    : ('' + callback.key).replace(userProvidedKeyEscapeRegex, '$&/') + '/') +
+                  childKey,
+              )),
+              '' !== nameSoFar &&
+                null != invokeCallback &&
+                isValidElement(invokeCallback) &&
+                null == invokeCallback.key &&
+                invokeCallback._store &&
+                !invokeCallback._store.validated &&
+                (escapedPrefix._store.validated = 2),
+              (callback = escapedPrefix)),
+            array.push(callback));
+        return 1;
+      }
+      invokeCallback = 0;
+      childKey = '' === nameSoFar ? '.' : nameSoFar + ':';
+      if (isArrayImpl(children))
+        for (var i = 0; i < children.length; i++)
+          (nameSoFar = children[i]),
+            (type = childKey + getElementKey(nameSoFar, i)),
+            (invokeCallback += mapIntoArray(nameSoFar, array, escapedPrefix, type, callback));
+      else if (((i = getIteratorFn(children)), 'function' === typeof i))
+        for (
+          i === children.entries &&
+            (didWarnAboutMaps ||
+              console.warn(
+                'Using Maps as children is not supported. Use an array of keyed ReactElements instead.',
+              ),
+            (didWarnAboutMaps = !0)),
+            children = i.call(children),
+            i = 0;
+          !(nameSoFar = children.next()).done;
+
+        )
+          (nameSoFar = nameSoFar.value),
+            (type = childKey + getElementKey(nameSoFar, i++)),
+            (invokeCallback += mapIntoArray(nameSoFar, array, escapedPrefix, type, callback));
+      else if ('object' === type) {
+        if ('function' === typeof children.then)
+          return mapIntoArray(resolveThenable(children), array, escapedPrefix, nameSoFar, callback);
+        array = String(children);
+        throw Error(
+          'Objects are not valid as a React child (found: ' +
+            ('[object Object]' === array
+              ? 'object with keys {' + Object.keys(children).join(', ') + '}'
+              : array) +
+            '). If you meant to render a collection of children, use an array instead.',
+        );
+      }
+      return invokeCallback;
+    }
+    function mapChildren(children, func, context) {
+      if (null == children) return children;
+      var result = [],
+        count = 0;
+      mapIntoArray(children, result, '', '', function (child) {
+        return func.call(context, child, count++);
+      });
+      return result;
+    }
+    function lazyInitializer(payload) {
+      if (-1 === payload._status) {
+        var ctor = payload._result;
+        ctor = ctor();
+        ctor.then(
+          function (moduleObject) {
+            if (0 === payload._status || -1 === payload._status)
+              (payload._status = 1), (payload._result = moduleObject);
+          },
+          function (error) {
+            if (0 === payload._status || -1 === payload._status)
+              (payload._status = 2), (payload._result = error);
+          },
+        );
+        -1 === payload._status && ((payload._status = 0), (payload._result = ctor));
+      }
+      if (1 === payload._status)
+        return (
+          (ctor = payload._result),
+          void 0 === ctor &&
+            console.error(
+              "lazy: Expected the result of a dynamic import() call. Instead received: %s\n\nYour code should look like: \n  const MyComponent = lazy(() => import('./MyComponent'))\n\nDid you accidentally put curly braces around the import?",
+              ctor,
+            ),
+          'default' in ctor ||
+            console.error(
+              "lazy: Expected the result of a dynamic import() call. Instead received: %s\n\nYour code should look like: \n  const MyComponent = lazy(() => import('./MyComponent'))",
+              ctor,
+            ),
+          ctor.default
+        );
+      throw payload._result;
+    }
+    function resolveDispatcher() {
+      var dispatcher = ReactSharedInternals.H;
+      null === dispatcher &&
+        console.error(
+          'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem.',
+        );
+      return dispatcher;
+    }
+    function noop() {}
+    function enqueueTask(task) {
+      if (null === enqueueTaskImpl)
+        try {
+          var requireString = ('require' + Math.random()).slice(0, 7);
+          enqueueTaskImpl = (module && module[requireString]).call(module, 'timers').setImmediate;
+        } catch (_err) {
+          enqueueTaskImpl = function (callback) {
+            !1 === didWarnAboutMessageChannel &&
+              ((didWarnAboutMessageChannel = !0),
+              'undefined' === typeof MessageChannel &&
+                console.error(
+                  'This browser does not have a MessageChannel implementation, so enqueuing tasks via await act(async () => ...) will fail. Please file an issue at https://github.com/facebook/react/issues if you encounter this warning.',
+                ));
+            var channel = new MessageChannel();
+            channel.port1.onmessage = callback;
+            channel.port2.postMessage(void 0);
+          };
+        }
+      return enqueueTaskImpl(task);
+    }
+    function aggregateErrors(errors) {
+      return 1 < errors.length && 'function' === typeof AggregateError
+        ? new AggregateError(errors)
+        : errors[0];
+    }
+    function popActScope(prevActQueue, prevActScopeDepth) {
+      prevActScopeDepth !== actScopeDepth - 1 &&
+        console.error(
+          'You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one. ',
+        );
+      actScopeDepth = prevActScopeDepth;
+    }
+    function recursivelyFlushAsyncActWork(returnValue, resolve, reject) {
+      var queue = ReactSharedInternals.actQueue;
+      if (null !== queue)
+        if (0 !== queue.length)
+          try {
+            flushActQueue(queue);
+            enqueueTask(function () {
+              return recursivelyFlushAsyncActWork(returnValue, resolve, reject);
+            });
+            return;
+          } catch (error) {
+            ReactSharedInternals.thrownErrors.push(error);
+          }
+        else ReactSharedInternals.actQueue = null;
+      0 < ReactSharedInternals.thrownErrors.length
+        ? ((queue = aggregateErrors(ReactSharedInternals.thrownErrors)),
+          (ReactSharedInternals.thrownErrors.length = 0),
+          reject(queue))
+        : resolve(returnValue);
+    }
+    function flushActQueue(queue) {
+      if (!isFlushing) {
+        isFlushing = !0;
+        var i = 0;
+        try {
+          for (; i < queue.length; i++) {
+            var callback = queue[i];
+            do {
+              ReactSharedInternals.didUsePromise = !1;
+              var continuation = callback(!1);
+              if (null !== continuation) {
+                if (ReactSharedInternals.didUsePromise) {
+                  queue[i] = callback;
+                  queue.splice(0, i);
+                  return;
+                }
+                callback = continuation;
+              } else break;
+            } while (1);
+          }
+          queue.length = 0;
+        } catch (error) {
+          queue.splice(0, i + 1), ReactSharedInternals.thrownErrors.push(error);
+        } finally {
+          isFlushing = !1;
+        }
+      }
+    }
+    'undefined' !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ &&
+      'function' === typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart &&
+      __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart(Error());
+    var REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
+      REACT_PORTAL_TYPE = Symbol.for('react.portal'),
+      REACT_FRAGMENT_TYPE = Symbol.for('react.fragment'),
+      REACT_STRICT_MODE_TYPE = Symbol.for('react.strict_mode'),
+      REACT_PROFILER_TYPE = Symbol.for('react.profiler');
+    Symbol.for('react.provider');
+    var REACT_CONSUMER_TYPE = Symbol.for('react.consumer'),
+      REACT_CONTEXT_TYPE = Symbol.for('react.context'),
+      REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref'),
+      REACT_SUSPENSE_TYPE = Symbol.for('react.suspense'),
+      REACT_SUSPENSE_LIST_TYPE = Symbol.for('react.suspense_list'),
+      REACT_MEMO_TYPE = Symbol.for('react.memo'),
+      REACT_LAZY_TYPE = Symbol.for('react.lazy'),
+      REACT_OFFSCREEN_TYPE = Symbol.for('react.offscreen'),
+      MAYBE_ITERATOR_SYMBOL = Symbol.iterator,
+      didWarnStateUpdateForUnmountedComponent = {},
+      ReactNoopUpdateQueue = {
+        isMounted: function () {
+          return !1;
+        },
+        enqueueForceUpdate: function (publicInstance) {
+          warnNoop(publicInstance, 'forceUpdate');
+        },
+        enqueueReplaceState: function (publicInstance) {
+          warnNoop(publicInstance, 'replaceState');
+        },
+        enqueueSetState: function (publicInstance) {
+          warnNoop(publicInstance, 'setState');
+        },
+      },
+      assign = Object.assign,
+      emptyObject = {};
+    Object.freeze(emptyObject);
+    Component.prototype.isReactComponent = {};
+    Component.prototype.setState = function (partialState, callback) {
+      if (
+        'object' !== typeof partialState &&
+        'function' !== typeof partialState &&
+        null != partialState
+      )
+        throw Error(
+          'takes an object of state variables to update or a function which returns an object of state variables.',
+        );
+      this.updater.enqueueSetState(this, partialState, callback, 'setState');
+    };
+    Component.prototype.forceUpdate = function (callback) {
+      this.updater.enqueueForceUpdate(this, callback, 'forceUpdate');
+    };
+    var deprecatedAPIs = {
+        isMounted: [
+          'isMounted',
+          'Instead, make sure to clean up subscriptions and pending requests in componentWillUnmount to prevent memory leaks.',
+        ],
+        replaceState: [
+          'replaceState',
+          'Refactor your code to use setState instead (see https://github.com/facebook/react/issues/3236).',
+        ],
+      },
+      fnName;
+    for (fnName in deprecatedAPIs)
+      deprecatedAPIs.hasOwnProperty(fnName) &&
+        defineDeprecationWarning(fnName, deprecatedAPIs[fnName]);
+    ComponentDummy.prototype = Component.prototype;
+    deprecatedAPIs = PureComponent.prototype = new ComponentDummy();
+    deprecatedAPIs.constructor = PureComponent;
+    assign(deprecatedAPIs, Component.prototype);
+    deprecatedAPIs.isPureReactComponent = !0;
+    var isArrayImpl = Array.isArray,
+      REACT_CLIENT_REFERENCE$2 = Symbol.for('react.client.reference'),
+      ReactSharedInternals = {
+        H: null,
+        A: null,
+        T: null,
+        S: null,
+        actQueue: null,
+        isBatchingLegacy: !1,
+        didScheduleLegacyUpdate: !1,
+        didUsePromise: !1,
+        thrownErrors: [],
+        getCurrentStack: null,
+      },
+      hasOwnProperty = Object.prototype.hasOwnProperty,
+      REACT_CLIENT_REFERENCE$1 = Symbol.for('react.client.reference'),
+      disabledDepth = 0,
+      prevLog,
+      prevInfo,
+      prevWarn,
+      prevError,
+      prevGroup,
+      prevGroupCollapsed,
+      prevGroupEnd;
+    disabledLog.__reactDisabledLog = !0;
+    var prefix,
+      suffix,
+      reentry = !1;
+    var componentFrameCache = new ('function' === typeof WeakMap ? WeakMap : Map)();
+    var REACT_CLIENT_REFERENCE = Symbol.for('react.client.reference'),
+      specialPropKeyWarningShown,
+      didWarnAboutOldJSXRuntime;
+    var didWarnAboutElementRef = {};
+    var ownerHasKeyUseWarning = {},
+      didWarnAboutMaps = !1,
+      userProvidedKeyEscapeRegex = /\/+/g,
+      reportGlobalError =
+        'function' === typeof reportError
+          ? reportError
+          : function (error) {
+              if ('object' === typeof window && 'function' === typeof window.ErrorEvent) {
+                var event = new window.ErrorEvent('error', {
+                  bubbles: !0,
+                  cancelable: !0,
+                  message:
+                    'object' === typeof error && null !== error && 'string' === typeof error.message
+                      ? String(error.message)
+                      : String(error),
+                  error: error,
+                });
+                if (!window.dispatchEvent(event)) return;
+              } else if ('object' === typeof process && 'function' === typeof process.emit) {
+                process.emit('uncaughtException', error);
+                return;
+              }
+              console.error(error);
+            },
+      didWarnAboutMessageChannel = !1,
+      enqueueTaskImpl = null,
+      actScopeDepth = 0,
+      didWarnNoAwaitAct = !1,
+      isFlushing = !1,
+      queueSeveralMicrotasks =
+        'function' === typeof queueMicrotask
+          ? function (callback) {
+              queueMicrotask(function () {
+                return queueMicrotask(callback);
+              });
+            }
+          : enqueueTask;
+    exports.Children = {
+      map: mapChildren,
+      forEach: function (children, forEachFunc, forEachContext) {
+        mapChildren(
+          children,
+          function () {
+            forEachFunc.apply(this, arguments);
+          },
+          forEachContext,
+        );
+      },
+      count: function (children) {
+        var n = 0;
+        mapChildren(children, function () {
+          n++;
+        });
+        return n;
+      },
+      toArray: function (children) {
+        return (
+          mapChildren(children, function (child) {
+            return child;
+          }) || []
+        );
+      },
+      only: function (children) {
+        if (!isValidElement(children))
+          throw Error('React.Children.only expected to receive a single React element child.');
+        return children;
+      },
+    };
+    exports.Component = Component;
+    exports.Fragment = REACT_FRAGMENT_TYPE;
+    exports.Profiler = REACT_PROFILER_TYPE;
+    exports.PureComponent = PureComponent;
+    exports.StrictMode = REACT_STRICT_MODE_TYPE;
+    exports.Suspense = REACT_SUSPENSE_TYPE;
+    exports.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = ReactSharedInternals;
+    exports.act = function (callback) {
+      var prevActQueue = ReactSharedInternals.actQueue,
+        prevActScopeDepth = actScopeDepth;
+      actScopeDepth++;
+      var queue = (ReactSharedInternals.actQueue = null !== prevActQueue ? prevActQueue : []),
+        didAwaitActCall = !1;
+      try {
+        var result = callback();
+      } catch (error) {
+        ReactSharedInternals.thrownErrors.push(error);
+      }
+      if (0 < ReactSharedInternals.thrownErrors.length)
+        throw (
+          (popActScope(prevActQueue, prevActScopeDepth),
+          (callback = aggregateErrors(ReactSharedInternals.thrownErrors)),
+          (ReactSharedInternals.thrownErrors.length = 0),
+          callback)
+        );
+      if (null !== result && 'object' === typeof result && 'function' === typeof result.then) {
+        var thenable = result;
+        queueSeveralMicrotasks(function () {
+          didAwaitActCall ||
+            didWarnNoAwaitAct ||
+            ((didWarnNoAwaitAct = !0),
+            console.error(
+              'You called act(async () => ...) without await. This could lead to unexpected testing behaviour, interleaving multiple act calls and mixing their scopes. You should - await act(async () => ...);',
+            ));
+        });
+        return {
+          then: function (resolve, reject) {
+            didAwaitActCall = !0;
+            thenable.then(
+              function (returnValue) {
+                popActScope(prevActQueue, prevActScopeDepth);
+                if (0 === prevActScopeDepth) {
+                  try {
+                    flushActQueue(queue),
+                      enqueueTask(function () {
+                        return recursivelyFlushAsyncActWork(returnValue, resolve, reject);
+                      });
+                  } catch (error$2) {
+                    ReactSharedInternals.thrownErrors.push(error$2);
+                  }
+                  if (0 < ReactSharedInternals.thrownErrors.length) {
+                    var _thrownError = aggregateErrors(ReactSharedInternals.thrownErrors);
+                    ReactSharedInternals.thrownErrors.length = 0;
+                    reject(_thrownError);
+                  }
+                } else resolve(returnValue);
+              },
+              function (error) {
+                popActScope(prevActQueue, prevActScopeDepth);
+                0 < ReactSharedInternals.thrownErrors.length
+                  ? ((error = aggregateErrors(ReactSharedInternals.thrownErrors)),
+                    (ReactSharedInternals.thrownErrors.length = 0),
+                    reject(error))
+                  : reject(error);
+              },
+            );
+          },
+        };
+      }
+      var returnValue$jscomp$0 = result;
+      popActScope(prevActQueue, prevActScopeDepth);
+      0 === prevActScopeDepth &&
+        (flushActQueue(queue),
+        0 !== queue.length &&
+          queueSeveralMicrotasks(function () {
+            didAwaitActCall ||
+              didWarnNoAwaitAct ||
+              ((didWarnNoAwaitAct = !0),
+              console.error(
+                'A component suspended inside an `act` scope, but the `act` call was not awaited. When testing React components that depend on asynchronous data, you must await the result:\n\nawait act(() => ...)',
+              ));
+          }),
+        (ReactSharedInternals.actQueue = null));
+      if (0 < ReactSharedInternals.thrownErrors.length)
+        throw (
+          ((callback = aggregateErrors(ReactSharedInternals.thrownErrors)),
+          (ReactSharedInternals.thrownErrors.length = 0),
+          callback)
+        );
+      return {
+        then: function (resolve, reject) {
+          didAwaitActCall = !0;
+          0 === prevActScopeDepth
+            ? ((ReactSharedInternals.actQueue = queue),
+              enqueueTask(function () {
+                return recursivelyFlushAsyncActWork(returnValue$jscomp$0, resolve, reject);
+              }))
+            : resolve(returnValue$jscomp$0);
+        },
+      };
+    };
+    exports.cache = function (fn) {
+      return function () {
+        return fn.apply(null, arguments);
+      };
+    };
+    exports.cloneElement = function (element, config, children) {
+      if (null === element || void 0 === element)
+        throw Error('The argument must be a React element, but you passed ' + element + '.');
+      var props = assign({}, element.props),
+        key = element.key,
+        owner = element._owner;
+      if (null != config) {
+        var JSCompiler_inline_result;
+        a: {
+          if (
+            hasOwnProperty.call(config, 'ref') &&
+            (JSCompiler_inline_result = Object.getOwnPropertyDescriptor(config, 'ref').get) &&
+            JSCompiler_inline_result.isReactWarning
+          ) {
+            JSCompiler_inline_result = !1;
+            break a;
+          }
+          JSCompiler_inline_result = void 0 !== config.ref;
+        }
+        JSCompiler_inline_result && (owner = getOwner());
+        hasValidKey(config) && (checkKeyStringCoercion(config.key), (key = '' + config.key));
+        for (propName in config)
+          !hasOwnProperty.call(config, propName) ||
+            'key' === propName ||
+            '__self' === propName ||
+            '__source' === propName ||
+            ('ref' === propName && void 0 === config.ref) ||
+            (props[propName] = config[propName]);
+      }
+      var propName = arguments.length - 2;
+      if (1 === propName) props.children = children;
+      else if (1 < propName) {
+        JSCompiler_inline_result = Array(propName);
+        for (var i = 0; i < propName; i++) JSCompiler_inline_result[i] = arguments[i + 2];
+        props.children = JSCompiler_inline_result;
+      }
+      props = ReactElement(element.type, key, void 0, void 0, owner, props);
+      for (key = 2; key < arguments.length; key++) validateChildKeys(arguments[key], props.type);
+      return props;
+    };
+    exports.createContext = function (defaultValue) {
+      defaultValue = {
+        $$typeof: REACT_CONTEXT_TYPE,
+        _currentValue: defaultValue,
+        _currentValue2: defaultValue,
+        _threadCount: 0,
+        Provider: null,
+        Consumer: null,
+      };
+      defaultValue.Provider = defaultValue;
+      defaultValue.Consumer = {
+        $$typeof: REACT_CONSUMER_TYPE,
+        _context: defaultValue,
+      };
+      defaultValue._currentRenderer = null;
+      defaultValue._currentRenderer2 = null;
+      return defaultValue;
+    };
+    exports.createElement = function (type, config, children) {
+      if (isValidElementType(type))
+        for (var i = 2; i < arguments.length; i++) validateChildKeys(arguments[i], type);
+      else {
+        i = '';
+        if (
+          void 0 === type ||
+          ('object' === typeof type && null !== type && 0 === Object.keys(type).length)
+        )
+          i +=
+            " You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.";
+        if (null === type) var typeString = 'null';
+        else
+          isArrayImpl(type)
+            ? (typeString = 'array')
+            : void 0 !== type && type.$$typeof === REACT_ELEMENT_TYPE
+            ? ((typeString = '<' + (getComponentNameFromType(type.type) || 'Unknown') + ' />'),
+              (i = ' Did you accidentally export a JSX literal instead of a component?'))
+            : (typeString = typeof type);
+        console.error(
+          'React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s',
+          typeString,
+          i,
+        );
+      }
+      var propName;
+      i = {};
+      typeString = null;
+      if (null != config)
+        for (propName in (didWarnAboutOldJSXRuntime ||
+          !('__self' in config) ||
+          'key' in config ||
+          ((didWarnAboutOldJSXRuntime = !0),
+          console.warn(
+            'Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform',
+          )),
+        hasValidKey(config) && (checkKeyStringCoercion(config.key), (typeString = '' + config.key)),
+        config))
+          hasOwnProperty.call(config, propName) &&
+            'key' !== propName &&
+            '__self' !== propName &&
+            '__source' !== propName &&
+            (i[propName] = config[propName]);
+      var childrenLength = arguments.length - 2;
+      if (1 === childrenLength) i.children = children;
+      else if (1 < childrenLength) {
+        for (var childArray = Array(childrenLength), _i = 0; _i < childrenLength; _i++)
+          childArray[_i] = arguments[_i + 2];
+        Object.freeze && Object.freeze(childArray);
+        i.children = childArray;
+      }
+      if (type && type.defaultProps)
+        for (propName in ((childrenLength = type.defaultProps), childrenLength))
+          void 0 === i[propName] && (i[propName] = childrenLength[propName]);
+      typeString &&
+        defineKeyPropWarningGetter(
+          i,
+          'function' === typeof type ? type.displayName || type.name || 'Unknown' : type,
+        );
+      return ReactElement(type, typeString, void 0, void 0, getOwner(), i);
+    };
+    exports.createRef = function () {
+      var refObject = {
+        current: null,
+      };
+      Object.seal(refObject);
+      return refObject;
+    };
+    exports.forwardRef = function (render) {
+      null != render && render.$$typeof === REACT_MEMO_TYPE
+        ? console.error(
+            'forwardRef requires a render function but received a `memo` component. Instead of forwardRef(memo(...)), use memo(forwardRef(...)).',
+          )
+        : 'function' !== typeof render
+        ? console.error(
+            'forwardRef requires a render function but was given %s.',
+            null === render ? 'null' : typeof render,
+          )
+        : 0 !== render.length &&
+          2 !== render.length &&
+          console.error(
+            'forwardRef render functions accept exactly two parameters: props and ref. %s',
+            1 === render.length
+              ? 'Did you forget to use the ref parameter?'
+              : 'Any additional parameter will be undefined.',
+          );
+      null != render &&
+        null != render.defaultProps &&
+        console.error(
+          'forwardRef render functions do not support defaultProps. Did you accidentally pass a React component?',
+        );
+      var elementType = {
+          $$typeof: REACT_FORWARD_REF_TYPE,
+          render: render,
+        },
+        ownName;
+      Object.defineProperty(elementType, 'displayName', {
+        enumerable: !1,
+        configurable: !0,
+        get: function () {
+          return ownName;
+        },
+        set: function (name) {
+          ownName = name;
+          render.name ||
+            render.displayName ||
+            (Object.defineProperty(render, 'name', {
+              value: name,
+            }),
+            (render.displayName = name));
+        },
+      });
+      return elementType;
+    };
+    exports.isValidElement = isValidElement;
+    exports.lazy = function (ctor) {
+      return {
+        $$typeof: REACT_LAZY_TYPE,
+        _payload: {
+          _status: -1,
+          _result: ctor,
+        },
+        _init: lazyInitializer,
+      };
+    };
+    exports.memo = function (type, compare) {
+      isValidElementType(type) ||
+        console.error(
+          'memo: The first argument must be a component. Instead received: %s',
+          null === type ? 'null' : typeof type,
+        );
+      compare = {
+        $$typeof: REACT_MEMO_TYPE,
+        type: type,
+        compare: void 0 === compare ? null : compare,
+      };
+      var ownName;
+      Object.defineProperty(compare, 'displayName', {
+        enumerable: !1,
+        configurable: !0,
+        get: function () {
+          return ownName;
+        },
+        set: function (name) {
+          ownName = name;
+          type.name ||
+            type.displayName ||
+            (Object.defineProperty(type, 'name', {
+              value: name,
+            }),
+            (type.displayName = name));
+        },
+      });
+      return compare;
+    };
+    exports.startTransition = function (scope) {
+      var prevTransition = ReactSharedInternals.T,
+        currentTransition = {};
+      ReactSharedInternals.T = currentTransition;
+      currentTransition._updatedFibers = new Set();
+      try {
+        var returnValue = scope(),
+          onStartTransitionFinish = ReactSharedInternals.S;
+        null !== onStartTransitionFinish && onStartTransitionFinish(currentTransition, returnValue);
+        'object' === typeof returnValue &&
+          null !== returnValue &&
+          'function' === typeof returnValue.then &&
+          returnValue.then(noop, reportGlobalError);
+      } catch (error) {
+        reportGlobalError(error);
+      } finally {
+        null === prevTransition &&
+          currentTransition._updatedFibers &&
+          ((scope = currentTransition._updatedFibers.size),
+          currentTransition._updatedFibers.clear(),
+          10 < scope &&
+            console.warn(
+              'Detected a large number of updates inside startTransition. If this is due to a subscription please re-write it to use React provided hooks. Otherwise concurrent mode guarantees are off the table.',
+            )),
+          (ReactSharedInternals.T = prevTransition);
+      }
+    };
+    exports.unstable_useCacheRefresh = function () {
+      return resolveDispatcher().useCacheRefresh();
+    };
+    exports.use = function (usable) {
+      return resolveDispatcher().use(usable);
+    };
+    exports.useActionState = function (action, initialState, permalink) {
+      return resolveDispatcher().useActionState(action, initialState, permalink);
+    };
+    exports.useCallback = function (callback, deps) {
+      return resolveDispatcher().useCallback(callback, deps);
+    };
+    exports.useContext = function (Context) {
+      var dispatcher = resolveDispatcher();
+      Context.$$typeof === REACT_CONSUMER_TYPE &&
+        console.error(
+          'Calling useContext(Context.Consumer) is not supported and will cause bugs. Did you mean to call useContext(Context) instead?',
+        );
+      return dispatcher.useContext(Context);
+    };
+    exports.useDebugValue = function (value, formatterFn) {
+      return resolveDispatcher().useDebugValue(value, formatterFn);
+    };
+    exports.useDeferredValue = function (value, initialValue) {
+      return resolveDispatcher().useDeferredValue(value, initialValue);
+    };
+    exports.useEffect = function (create, deps) {
+      return resolveDispatcher().useEffect(create, deps);
+    };
+    exports.useId = function () {
+      return resolveDispatcher().useId();
+    };
+    exports.useImperativeHandle = function (ref, create, deps) {
+      return resolveDispatcher().useImperativeHandle(ref, create, deps);
+    };
+    exports.useInsertionEffect = function (create, deps) {
+      return resolveDispatcher().useInsertionEffect(create, deps);
+    };
+    exports.useLayoutEffect = function (create, deps) {
+      return resolveDispatcher().useLayoutEffect(create, deps);
+    };
+    exports.useMemo = function (create, deps) {
+      return resolveDispatcher().useMemo(create, deps);
+    };
+    exports.useOptimistic = function (passthrough, reducer) {
+      return resolveDispatcher().useOptimistic(passthrough, reducer);
+    };
+    exports.useReducer = function (reducer, initialArg, init) {
+      return resolveDispatcher().useReducer(reducer, initialArg, init);
+    };
+    exports.useRef = function (initialValue) {
+      return resolveDispatcher().useRef(initialValue);
+    };
+    exports.useState = function (initialState) {
+      return resolveDispatcher().useState(initialState);
+    };
+    exports.useSyncExternalStore = function (subscribe, getSnapshot, getServerSnapshot) {
+      return resolveDispatcher().useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+    };
+    exports.useTransition = function () {
+      return resolveDispatcher().useTransition();
+    };
+    exports.version = '19.0.0';
+    'undefined' !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ &&
+      'function' === typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop &&
+      __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(Error());
+  })();

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
@@ -820,7 +820,8 @@ if (process.env.NODE_ENV !== 'production') {
         if (
           type.$$typeof &&
           (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-            type.$$typeof.toString() === 'Symbol(react.element)')
+            type.$$typeof.toString() === 'Symbol(react.element)' ||
+            type.$$typeof.toString() === 'Symbol(react.transitional.element)')
         ) {
           if (props) {
             const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/code.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/code.js
@@ -1,0 +1,586 @@
+/**
+ * @license React
+ * react-jsx-runtime.development.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+'production' !== process.env.NODE_ENV &&
+  (function () {
+    function getComponentNameFromType(type) {
+      if (null == type) return null;
+      if ('function' === typeof type)
+        return type.$$typeof === REACT_CLIENT_REFERENCE$2
+          ? null
+          : type.displayName || type.name || null;
+      if ('string' === typeof type) return type;
+      switch (type) {
+        case REACT_FRAGMENT_TYPE:
+          return 'Fragment';
+        case REACT_PORTAL_TYPE:
+          return 'Portal';
+        case REACT_PROFILER_TYPE:
+          return 'Profiler';
+        case REACT_STRICT_MODE_TYPE:
+          return 'StrictMode';
+        case REACT_SUSPENSE_TYPE:
+          return 'Suspense';
+        case REACT_SUSPENSE_LIST_TYPE:
+          return 'SuspenseList';
+      }
+      if ('object' === typeof type)
+        switch (
+          ('number' === typeof type.tag &&
+            console.error(
+              'Received an unexpected object in getComponentNameFromType(). This is likely a bug in React. Please file an issue.',
+            ),
+          type.$$typeof)
+        ) {
+          case REACT_CONTEXT_TYPE:
+            return (type.displayName || 'Context') + '.Provider';
+          case REACT_CONSUMER_TYPE:
+            return (type._context.displayName || 'Context') + '.Consumer';
+          case REACT_FORWARD_REF_TYPE:
+            var innerType = type.render;
+            type = type.displayName;
+            type ||
+              ((type = innerType.displayName || innerType.name || ''),
+              (type = '' !== type ? 'ForwardRef(' + type + ')' : 'ForwardRef'));
+            return type;
+          case REACT_MEMO_TYPE:
+            return (
+              (innerType = type.displayName || null),
+              null !== innerType ? innerType : getComponentNameFromType(type.type) || 'Memo'
+            );
+          case REACT_LAZY_TYPE:
+            innerType = type._payload;
+            type = type._init;
+            try {
+              return getComponentNameFromType(type(innerType));
+            } catch (x) {}
+        }
+      return null;
+    }
+    function testStringCoercion(value) {
+      return '' + value;
+    }
+    function checkKeyStringCoercion(value) {
+      try {
+        testStringCoercion(value);
+        var JSCompiler_inline_result = !1;
+      } catch (e) {
+        JSCompiler_inline_result = !0;
+      }
+      if (JSCompiler_inline_result) {
+        JSCompiler_inline_result = console;
+        var JSCompiler_temp_const = JSCompiler_inline_result.error;
+        var JSCompiler_inline_result$jscomp$0 =
+          ('function' === typeof Symbol && Symbol.toStringTag && value[Symbol.toStringTag]) ||
+          value.constructor.name ||
+          'Object';
+        JSCompiler_temp_const.call(
+          JSCompiler_inline_result,
+          'The provided key is an unsupported type %s. This value must be coerced to a string before using it here.',
+          JSCompiler_inline_result$jscomp$0,
+        );
+        return testStringCoercion(value);
+      }
+    }
+    function disabledLog() {}
+    function disableLogs() {
+      if (0 === disabledDepth) {
+        prevLog = console.log;
+        prevInfo = console.info;
+        prevWarn = console.warn;
+        prevError = console.error;
+        prevGroup = console.group;
+        prevGroupCollapsed = console.groupCollapsed;
+        prevGroupEnd = console.groupEnd;
+        var props = {
+          configurable: !0,
+          enumerable: !0,
+          value: disabledLog,
+          writable: !0,
+        };
+        Object.defineProperties(console, {
+          info: props,
+          log: props,
+          warn: props,
+          error: props,
+          group: props,
+          groupCollapsed: props,
+          groupEnd: props,
+        });
+      }
+      disabledDepth++;
+    }
+    function reenableLogs() {
+      disabledDepth--;
+      if (0 === disabledDepth) {
+        var props = { configurable: !0, enumerable: !0, writable: !0 };
+        Object.defineProperties(console, {
+          log: assign({}, props, { value: prevLog }),
+          info: assign({}, props, { value: prevInfo }),
+          warn: assign({}, props, { value: prevWarn }),
+          error: assign({}, props, { value: prevError }),
+          group: assign({}, props, { value: prevGroup }),
+          groupCollapsed: assign({}, props, { value: prevGroupCollapsed }),
+          groupEnd: assign({}, props, { value: prevGroupEnd }),
+        });
+      }
+      0 > disabledDepth &&
+        console.error(
+          'disabledDepth fell below zero. This is a bug in React. Please file an issue.',
+        );
+    }
+    function describeBuiltInComponentFrame(name) {
+      if (void 0 === prefix)
+        try {
+          throw Error();
+        } catch (x) {
+          var match = x.stack.trim().match(/\n( *(at )?)/);
+          prefix = (match && match[1]) || '';
+          suffix =
+            -1 < x.stack.indexOf('\n    at')
+              ? ' (<anonymous>)'
+              : -1 < x.stack.indexOf('@')
+              ? '@unknown:0:0'
+              : '';
+        }
+      return '\n' + prefix + name + suffix;
+    }
+    function describeNativeComponentFrame(fn, construct) {
+      if (!fn || reentry) return '';
+      var frame = componentFrameCache.get(fn);
+      if (void 0 !== frame) return frame;
+      reentry = !0;
+      frame = Error.prepareStackTrace;
+      Error.prepareStackTrace = void 0;
+      var previousDispatcher = null;
+      previousDispatcher = ReactSharedInternals.H;
+      ReactSharedInternals.H = null;
+      disableLogs();
+      try {
+        var RunInRootFrame = {
+          DetermineComponentFrameRoot: function () {
+            try {
+              if (construct) {
+                var Fake = function () {
+                  throw Error();
+                };
+                Object.defineProperty(Fake.prototype, 'props', {
+                  set: function () {
+                    throw Error();
+                  },
+                });
+                if ('object' === typeof Reflect && Reflect.construct) {
+                  try {
+                    Reflect.construct(Fake, []);
+                  } catch (x) {
+                    var control = x;
+                  }
+                  Reflect.construct(fn, [], Fake);
+                } else {
+                  try {
+                    Fake.call();
+                  } catch (x$0) {
+                    control = x$0;
+                  }
+                  fn.call(Fake.prototype);
+                }
+              } else {
+                try {
+                  throw Error();
+                } catch (x$1) {
+                  control = x$1;
+                }
+                (Fake = fn()) && 'function' === typeof Fake.catch && Fake.catch(function () {});
+              }
+            } catch (sample) {
+              if (sample && control && 'string' === typeof sample.stack)
+                return [sample.stack, control.stack];
+            }
+            return [null, null];
+          },
+        };
+        RunInRootFrame.DetermineComponentFrameRoot.displayName = 'DetermineComponentFrameRoot';
+        var namePropDescriptor = Object.getOwnPropertyDescriptor(
+          RunInRootFrame.DetermineComponentFrameRoot,
+          'name',
+        );
+        namePropDescriptor &&
+          namePropDescriptor.configurable &&
+          Object.defineProperty(RunInRootFrame.DetermineComponentFrameRoot, 'name', {
+            value: 'DetermineComponentFrameRoot',
+          });
+        var _RunInRootFrame$Deter = RunInRootFrame.DetermineComponentFrameRoot(),
+          sampleStack = _RunInRootFrame$Deter[0],
+          controlStack = _RunInRootFrame$Deter[1];
+        if (sampleStack && controlStack) {
+          var sampleLines = sampleStack.split('\n'),
+            controlLines = controlStack.split('\n');
+          for (
+            _RunInRootFrame$Deter = namePropDescriptor = 0;
+            namePropDescriptor < sampleLines.length &&
+            !sampleLines[namePropDescriptor].includes('DetermineComponentFrameRoot');
+
+          )
+            namePropDescriptor++;
+          for (
+            ;
+            _RunInRootFrame$Deter < controlLines.length &&
+            !controlLines[_RunInRootFrame$Deter].includes('DetermineComponentFrameRoot');
+
+          )
+            _RunInRootFrame$Deter++;
+          if (
+            namePropDescriptor === sampleLines.length ||
+            _RunInRootFrame$Deter === controlLines.length
+          )
+            for (
+              namePropDescriptor = sampleLines.length - 1,
+                _RunInRootFrame$Deter = controlLines.length - 1;
+              1 <= namePropDescriptor &&
+              0 <= _RunInRootFrame$Deter &&
+              sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter];
+
+            )
+              _RunInRootFrame$Deter--;
+          for (
+            ;
+            1 <= namePropDescriptor && 0 <= _RunInRootFrame$Deter;
+            namePropDescriptor--, _RunInRootFrame$Deter--
+          )
+            if (sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter]) {
+              if (1 !== namePropDescriptor || 1 !== _RunInRootFrame$Deter) {
+                do
+                  if (
+                    (namePropDescriptor--,
+                    _RunInRootFrame$Deter--,
+                    0 > _RunInRootFrame$Deter ||
+                      sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter])
+                  ) {
+                    var _frame = '\n' + sampleLines[namePropDescriptor].replace(' at new ', ' at ');
+                    fn.displayName &&
+                      _frame.includes('<anonymous>') &&
+                      (_frame = _frame.replace('<anonymous>', fn.displayName));
+                    'function' === typeof fn && componentFrameCache.set(fn, _frame);
+                    return _frame;
+                  }
+                while (1 <= namePropDescriptor && 0 <= _RunInRootFrame$Deter);
+              }
+              break;
+            }
+        }
+      } finally {
+        (reentry = !1),
+          (ReactSharedInternals.H = previousDispatcher),
+          reenableLogs(),
+          (Error.prepareStackTrace = frame);
+      }
+      sampleLines = (sampleLines = fn ? fn.displayName || fn.name : '')
+        ? describeBuiltInComponentFrame(sampleLines)
+        : '';
+      'function' === typeof fn && componentFrameCache.set(fn, sampleLines);
+      return sampleLines;
+    }
+    function describeUnknownElementTypeFrameInDEV(type) {
+      if (null == type) return '';
+      if ('function' === typeof type) {
+        var prototype = type.prototype;
+        return describeNativeComponentFrame(type, !(!prototype || !prototype.isReactComponent));
+      }
+      if ('string' === typeof type) return describeBuiltInComponentFrame(type);
+      switch (type) {
+        case REACT_SUSPENSE_TYPE:
+          return describeBuiltInComponentFrame('Suspense');
+        case REACT_SUSPENSE_LIST_TYPE:
+          return describeBuiltInComponentFrame('SuspenseList');
+      }
+      if ('object' === typeof type)
+        switch (type.$$typeof) {
+          case REACT_FORWARD_REF_TYPE:
+            return (type = describeNativeComponentFrame(type.render, !1)), type;
+          case REACT_MEMO_TYPE:
+            return describeUnknownElementTypeFrameInDEV(type.type);
+          case REACT_LAZY_TYPE:
+            prototype = type._payload;
+            type = type._init;
+            try {
+              return describeUnknownElementTypeFrameInDEV(type(prototype));
+            } catch (x) {}
+        }
+      return '';
+    }
+    function getOwner() {
+      var dispatcher = ReactSharedInternals.A;
+      return null === dispatcher ? null : dispatcher.getOwner();
+    }
+    function hasValidKey(config) {
+      if (hasOwnProperty.call(config, 'key')) {
+        var getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+        if (getter && getter.isReactWarning) return !1;
+      }
+      return void 0 !== config.key;
+    }
+    function defineKeyPropWarningGetter(props, displayName) {
+      function warnAboutAccessingKey() {
+        specialPropKeyWarningShown ||
+          ((specialPropKeyWarningShown = !0),
+          console.error(
+            '%s: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://react.dev/link/special-props)',
+            displayName,
+          ));
+      }
+      warnAboutAccessingKey.isReactWarning = !0;
+      Object.defineProperty(props, 'key', {
+        get: warnAboutAccessingKey,
+        configurable: !0,
+      });
+    }
+    function elementRefGetterWithDeprecationWarning() {
+      var componentName = getComponentNameFromType(this.type);
+      didWarnAboutElementRef[componentName] ||
+        ((didWarnAboutElementRef[componentName] = !0),
+        console.error(
+          'Accessing element.ref was removed in React 19. ref is now a regular prop. It will be removed from the JSX Element type in a future release.',
+        ));
+      componentName = this.props.ref;
+      return void 0 !== componentName ? componentName : null;
+    }
+    function ReactElement(type, key, self, source, owner, props) {
+      self = props.ref;
+      type = {
+        $$typeof: REACT_ELEMENT_TYPE,
+        type: type,
+        key: key,
+        props: props,
+        _owner: owner,
+      };
+      null !== (void 0 !== self ? self : null)
+        ? Object.defineProperty(type, 'ref', {
+            enumerable: !1,
+            get: elementRefGetterWithDeprecationWarning,
+          })
+        : Object.defineProperty(type, 'ref', { enumerable: !1, value: null });
+      type._store = {};
+      Object.defineProperty(type._store, 'validated', {
+        configurable: !1,
+        enumerable: !1,
+        writable: !0,
+        value: 0,
+      });
+      Object.defineProperty(type, '_debugInfo', {
+        configurable: !1,
+        enumerable: !1,
+        writable: !0,
+        value: null,
+      });
+      Object.freeze && (Object.freeze(type.props), Object.freeze(type));
+      return type;
+    }
+    function jsxDEVImpl(type, config, maybeKey, isStaticChildren, source, self) {
+      if (
+        'string' === typeof type ||
+        'function' === typeof type ||
+        type === REACT_FRAGMENT_TYPE ||
+        type === REACT_PROFILER_TYPE ||
+        type === REACT_STRICT_MODE_TYPE ||
+        type === REACT_SUSPENSE_TYPE ||
+        type === REACT_SUSPENSE_LIST_TYPE ||
+        type === REACT_OFFSCREEN_TYPE ||
+        ('object' === typeof type &&
+          null !== type &&
+          (type.$$typeof === REACT_LAZY_TYPE ||
+            type.$$typeof === REACT_MEMO_TYPE ||
+            type.$$typeof === REACT_CONTEXT_TYPE ||
+            type.$$typeof === REACT_CONSUMER_TYPE ||
+            type.$$typeof === REACT_FORWARD_REF_TYPE ||
+            type.$$typeof === REACT_CLIENT_REFERENCE$1 ||
+            void 0 !== type.getModuleId))
+      ) {
+        var children = config.children;
+        if (void 0 !== children)
+          if (isStaticChildren)
+            if (isArrayImpl(children)) {
+              for (isStaticChildren = 0; isStaticChildren < children.length; isStaticChildren++)
+                validateChildKeys(children[isStaticChildren], type);
+              Object.freeze && Object.freeze(children);
+            } else
+              console.error(
+                'React.jsx: Static children should always be an array. You are likely explicitly calling React.jsxs or React.jsxDEV. Use the Babel transform instead.',
+              );
+          else validateChildKeys(children, type);
+      } else {
+        children = '';
+        if (
+          void 0 === type ||
+          ('object' === typeof type && null !== type && 0 === Object.keys(type).length)
+        )
+          children +=
+            " You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.";
+        null === type
+          ? (isStaticChildren = 'null')
+          : isArrayImpl(type)
+          ? (isStaticChildren = 'array')
+          : void 0 !== type && type.$$typeof === REACT_ELEMENT_TYPE
+          ? ((isStaticChildren = '<' + (getComponentNameFromType(type.type) || 'Unknown') + ' />'),
+            (children = ' Did you accidentally export a JSX literal instead of a component?'))
+          : (isStaticChildren = typeof type);
+        console.error(
+          'React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s',
+          isStaticChildren,
+          children,
+        );
+      }
+      if (hasOwnProperty.call(config, 'key')) {
+        children = getComponentNameFromType(type);
+        var keys = Object.keys(config).filter(function (k) {
+          return 'key' !== k;
+        });
+        isStaticChildren =
+          0 < keys.length ? '{key: someKey, ' + keys.join(': ..., ') + ': ...}' : '{key: someKey}';
+        didWarnAboutKeySpread[children + isStaticChildren] ||
+          ((keys = 0 < keys.length ? '{' + keys.join(': ..., ') + ': ...}' : '{}'),
+          console.error(
+            'A props object containing a "key" prop is being spread into JSX:\n  let props = %s;\n  <%s {...props} />\nReact keys must be passed directly to JSX without using spread:\n  let props = %s;\n  <%s key={someKey} {...props} />',
+            isStaticChildren,
+            children,
+            keys,
+            children,
+          ),
+          (didWarnAboutKeySpread[children + isStaticChildren] = !0));
+      }
+      children = null;
+      void 0 !== maybeKey && (checkKeyStringCoercion(maybeKey), (children = '' + maybeKey));
+      hasValidKey(config) && (checkKeyStringCoercion(config.key), (children = '' + config.key));
+      if ('key' in config) {
+        maybeKey = {};
+        for (var propName in config) 'key' !== propName && (maybeKey[propName] = config[propName]);
+      } else maybeKey = config;
+      children &&
+        defineKeyPropWarningGetter(
+          maybeKey,
+          'function' === typeof type ? type.displayName || type.name || 'Unknown' : type,
+        );
+      return ReactElement(type, children, self, source, getOwner(), maybeKey);
+    }
+    function validateChildKeys(node, parentType) {
+      if ('object' === typeof node && node && node.$$typeof !== REACT_CLIENT_REFERENCE)
+        if (isArrayImpl(node))
+          for (var i = 0; i < node.length; i++) {
+            var child = node[i];
+            isValidElement(child) && validateExplicitKey(child, parentType);
+          }
+        else if (isValidElement(node)) node._store && (node._store.validated = 1);
+        else if (
+          (null === node || 'object' !== typeof node
+            ? (i = null)
+            : ((i = (MAYBE_ITERATOR_SYMBOL && node[MAYBE_ITERATOR_SYMBOL]) || node['@@iterator']),
+              (i = 'function' === typeof i ? i : null)),
+          'function' === typeof i && i !== node.entries && ((i = i.call(node)), i !== node))
+        )
+          for (; !(node = i.next()).done; )
+            isValidElement(node.value) && validateExplicitKey(node.value, parentType);
+    }
+    function isValidElement(object) {
+      return (
+        'object' === typeof object && null !== object && object.$$typeof === REACT_ELEMENT_TYPE
+      );
+    }
+    function validateExplicitKey(element, parentType) {
+      if (
+        element._store &&
+        !element._store.validated &&
+        null == element.key &&
+        ((element._store.validated = 1),
+        (parentType = getCurrentComponentErrorInfo(parentType)),
+        !ownerHasKeyUseWarning[parentType])
+      ) {
+        ownerHasKeyUseWarning[parentType] = !0;
+        var childOwner = '';
+        element &&
+          null != element._owner &&
+          element._owner !== getOwner() &&
+          ((childOwner = null),
+          'number' === typeof element._owner.tag
+            ? (childOwner = getComponentNameFromType(element._owner.type))
+            : 'string' === typeof element._owner.name && (childOwner = element._owner.name),
+          (childOwner = ' It was passed a child from ' + childOwner + '.'));
+        var prevGetCurrentStack = ReactSharedInternals.getCurrentStack;
+        ReactSharedInternals.getCurrentStack = function () {
+          var stack = describeUnknownElementTypeFrameInDEV(element.type);
+          prevGetCurrentStack && (stack += prevGetCurrentStack() || '');
+          return stack;
+        };
+        console.error(
+          'Each child in a list should have a unique "key" prop.%s%s See https://react.dev/link/warning-keys for more information.',
+          parentType,
+          childOwner,
+        );
+        ReactSharedInternals.getCurrentStack = prevGetCurrentStack;
+      }
+    }
+    function getCurrentComponentErrorInfo(parentType) {
+      var info = '',
+        owner = getOwner();
+      owner &&
+        (owner = getComponentNameFromType(owner.type)) &&
+        (info = '\n\nCheck the render method of `' + owner + '`.');
+      info ||
+        ((parentType = getComponentNameFromType(parentType)) &&
+          (info = '\n\nCheck the top-level render call using <' + parentType + '>.'));
+      return info;
+    }
+    var React = require('react'),
+      REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
+      REACT_PORTAL_TYPE = Symbol.for('react.portal'),
+      REACT_FRAGMENT_TYPE = Symbol.for('react.fragment'),
+      REACT_STRICT_MODE_TYPE = Symbol.for('react.strict_mode'),
+      REACT_PROFILER_TYPE = Symbol.for('react.profiler');
+    Symbol.for('react.provider');
+    var REACT_CONSUMER_TYPE = Symbol.for('react.consumer'),
+      REACT_CONTEXT_TYPE = Symbol.for('react.context'),
+      REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref'),
+      REACT_SUSPENSE_TYPE = Symbol.for('react.suspense'),
+      REACT_SUSPENSE_LIST_TYPE = Symbol.for('react.suspense_list'),
+      REACT_MEMO_TYPE = Symbol.for('react.memo'),
+      REACT_LAZY_TYPE = Symbol.for('react.lazy'),
+      REACT_OFFSCREEN_TYPE = Symbol.for('react.offscreen'),
+      MAYBE_ITERATOR_SYMBOL = Symbol.iterator,
+      REACT_CLIENT_REFERENCE$2 = Symbol.for('react.client.reference'),
+      ReactSharedInternals = React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
+      hasOwnProperty = Object.prototype.hasOwnProperty,
+      assign = Object.assign,
+      REACT_CLIENT_REFERENCE$1 = Symbol.for('react.client.reference'),
+      isArrayImpl = Array.isArray,
+      disabledDepth = 0,
+      prevLog,
+      prevInfo,
+      prevWarn,
+      prevError,
+      prevGroup,
+      prevGroupCollapsed,
+      prevGroupEnd;
+    disabledLog.__reactDisabledLog = !0;
+    var prefix,
+      suffix,
+      reentry = !1;
+    var componentFrameCache = new ('function' === typeof WeakMap ? WeakMap : Map)();
+    var REACT_CLIENT_REFERENCE = Symbol.for('react.client.reference'),
+      specialPropKeyWarningShown;
+    var didWarnAboutElementRef = {};
+    var didWarnAboutKeySpread = {},
+      ownerHasKeyUseWarning = {};
+    exports.Fragment = REACT_FRAGMENT_TYPE;
+    exports.jsx = function (type, config, maybeKey, source, self) {
+      return jsxDEVImpl(type, config, maybeKey, !1, source, self);
+    };
+    exports.jsxs = function (type, config, maybeKey, source, self) {
+      return jsxDEVImpl(type, config, maybeKey, !0, source, self);
+    };
+  })();

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/options.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/options.js
@@ -1,0 +1,10 @@
+import * as path from 'path';
+
+module.exports = {
+  babelOptions: {
+    filename: path.join(
+      __dirname,
+      'ReactNativeNewArch/node_modules/react/cjs/react-jsx-runtime.development.js',
+    ),
+  },
+};

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
@@ -1,0 +1,639 @@
+/**
+ * @license React
+ * react-jsx-runtime.development.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+'production' !== process.env.NODE_ENV &&
+  (function () {
+    function getComponentNameFromType(type) {
+      if (null == type) return null;
+      if ('function' === typeof type)
+        return type.$$typeof === REACT_CLIENT_REFERENCE$2
+          ? null
+          : type.displayName || type.name || null;
+      if ('string' === typeof type) return type;
+      switch (type) {
+        case REACT_FRAGMENT_TYPE:
+          return 'Fragment';
+        case REACT_PORTAL_TYPE:
+          return 'Portal';
+        case REACT_PROFILER_TYPE:
+          return 'Profiler';
+        case REACT_STRICT_MODE_TYPE:
+          return 'StrictMode';
+        case REACT_SUSPENSE_TYPE:
+          return 'Suspense';
+        case REACT_SUSPENSE_LIST_TYPE:
+          return 'SuspenseList';
+      }
+      if ('object' === typeof type)
+        switch (
+          ('number' === typeof type.tag &&
+            console.error(
+              'Received an unexpected object in getComponentNameFromType(). This is likely a bug in React. Please file an issue.',
+            ),
+          type.$$typeof)
+        ) {
+          case REACT_CONTEXT_TYPE:
+            return (type.displayName || 'Context') + '.Provider';
+          case REACT_CONSUMER_TYPE:
+            return (type._context.displayName || 'Context') + '.Consumer';
+          case REACT_FORWARD_REF_TYPE:
+            var innerType = type.render;
+            type = type.displayName;
+            type ||
+              ((type = innerType.displayName || innerType.name || ''),
+              (type = '' !== type ? 'ForwardRef(' + type + ')' : 'ForwardRef'));
+            return type;
+          case REACT_MEMO_TYPE:
+            return (
+              (innerType = type.displayName || null),
+              null !== innerType ? innerType : getComponentNameFromType(type.type) || 'Memo'
+            );
+          case REACT_LAZY_TYPE:
+            innerType = type._payload;
+            type = type._init;
+            try {
+              return getComponentNameFromType(type(innerType));
+            } catch (x) {}
+        }
+      return null;
+    }
+    function testStringCoercion(value) {
+      return '' + value;
+    }
+    function checkKeyStringCoercion(value) {
+      try {
+        testStringCoercion(value);
+        var JSCompiler_inline_result = !1;
+      } catch (e) {
+        JSCompiler_inline_result = !0;
+      }
+      if (JSCompiler_inline_result) {
+        JSCompiler_inline_result = console;
+        var JSCompiler_temp_const = JSCompiler_inline_result.error;
+        var JSCompiler_inline_result$jscomp$0 =
+          ('function' === typeof Symbol && Symbol.toStringTag && value[Symbol.toStringTag]) ||
+          value.constructor.name ||
+          'Object';
+        JSCompiler_temp_const.call(
+          JSCompiler_inline_result,
+          'The provided key is an unsupported type %s. This value must be coerced to a string before using it here.',
+          JSCompiler_inline_result$jscomp$0,
+        );
+        return testStringCoercion(value);
+      }
+    }
+    function disabledLog() {}
+    function disableLogs() {
+      if (0 === disabledDepth) {
+        prevLog = console.log;
+        prevInfo = console.info;
+        prevWarn = console.warn;
+        prevError = console.error;
+        prevGroup = console.group;
+        prevGroupCollapsed = console.groupCollapsed;
+        prevGroupEnd = console.groupEnd;
+        var props = {
+          configurable: !0,
+          enumerable: !0,
+          value: disabledLog,
+          writable: !0,
+        };
+        Object.defineProperties(console, {
+          info: props,
+          log: props,
+          warn: props,
+          error: props,
+          group: props,
+          groupCollapsed: props,
+          groupEnd: props,
+        });
+      }
+      disabledDepth++;
+    }
+    function reenableLogs() {
+      disabledDepth--;
+      if (0 === disabledDepth) {
+        var props = {
+          configurable: !0,
+          enumerable: !0,
+          writable: !0,
+        };
+        Object.defineProperties(console, {
+          log: assign({}, props, {
+            value: prevLog,
+          }),
+          info: assign({}, props, {
+            value: prevInfo,
+          }),
+          warn: assign({}, props, {
+            value: prevWarn,
+          }),
+          error: assign({}, props, {
+            value: prevError,
+          }),
+          group: assign({}, props, {
+            value: prevGroup,
+          }),
+          groupCollapsed: assign({}, props, {
+            value: prevGroupCollapsed,
+          }),
+          groupEnd: assign({}, props, {
+            value: prevGroupEnd,
+          }),
+        });
+      }
+      0 > disabledDepth &&
+        console.error(
+          'disabledDepth fell below zero. This is a bug in React. Please file an issue.',
+        );
+    }
+    function describeBuiltInComponentFrame(name) {
+      if (void 0 === prefix)
+        try {
+          throw Error();
+        } catch (x) {
+          var match = x.stack.trim().match(/\n( *(at )?)/);
+          prefix = (match && match[1]) || '';
+          suffix =
+            -1 < x.stack.indexOf('\n    at')
+              ? ' (<anonymous>)'
+              : -1 < x.stack.indexOf('@')
+              ? '@unknown:0:0'
+              : '';
+        }
+      return '\n' + prefix + name + suffix;
+    }
+    function describeNativeComponentFrame(fn, construct) {
+      if (!fn || reentry) return '';
+      var frame = componentFrameCache.get(fn);
+      if (void 0 !== frame) return frame;
+      reentry = !0;
+      frame = Error.prepareStackTrace;
+      Error.prepareStackTrace = void 0;
+      var previousDispatcher = null;
+      previousDispatcher = ReactSharedInternals.H;
+      ReactSharedInternals.H = null;
+      disableLogs();
+      try {
+        var RunInRootFrame = {
+          DetermineComponentFrameRoot: function () {
+            try {
+              if (construct) {
+                var Fake = function () {
+                  throw Error();
+                };
+                Object.defineProperty(Fake.prototype, 'props', {
+                  set: function () {
+                    throw Error();
+                  },
+                });
+                if ('object' === typeof Reflect && Reflect.construct) {
+                  try {
+                    Reflect.construct(Fake, []);
+                  } catch (x) {
+                    var control = x;
+                  }
+                  Reflect.construct(fn, [], Fake);
+                } else {
+                  try {
+                    Fake.call();
+                  } catch (x$0) {
+                    control = x$0;
+                  }
+                  fn.call(Fake.prototype);
+                }
+              } else {
+                try {
+                  throw Error();
+                } catch (x$1) {
+                  control = x$1;
+                }
+                (Fake = fn()) && 'function' === typeof Fake.catch && Fake.catch(function () {});
+              }
+            } catch (sample) {
+              if (sample && control && 'string' === typeof sample.stack)
+                return [sample.stack, control.stack];
+            }
+            return [null, null];
+          },
+        };
+        RunInRootFrame.DetermineComponentFrameRoot.displayName = 'DetermineComponentFrameRoot';
+        var namePropDescriptor = Object.getOwnPropertyDescriptor(
+          RunInRootFrame.DetermineComponentFrameRoot,
+          'name',
+        );
+        namePropDescriptor &&
+          namePropDescriptor.configurable &&
+          Object.defineProperty(RunInRootFrame.DetermineComponentFrameRoot, 'name', {
+            value: 'DetermineComponentFrameRoot',
+          });
+        var _RunInRootFrame$Deter = RunInRootFrame.DetermineComponentFrameRoot(),
+          sampleStack = _RunInRootFrame$Deter[0],
+          controlStack = _RunInRootFrame$Deter[1];
+        if (sampleStack && controlStack) {
+          var sampleLines = sampleStack.split('\n'),
+            controlLines = controlStack.split('\n');
+          for (
+            _RunInRootFrame$Deter = namePropDescriptor = 0;
+            namePropDescriptor < sampleLines.length &&
+            !sampleLines[namePropDescriptor].includes('DetermineComponentFrameRoot');
+
+          )
+            namePropDescriptor++;
+          for (
+            ;
+            _RunInRootFrame$Deter < controlLines.length &&
+            !controlLines[_RunInRootFrame$Deter].includes('DetermineComponentFrameRoot');
+
+          )
+            _RunInRootFrame$Deter++;
+          if (
+            namePropDescriptor === sampleLines.length ||
+            _RunInRootFrame$Deter === controlLines.length
+          )
+            for (
+              namePropDescriptor = sampleLines.length - 1,
+                _RunInRootFrame$Deter = controlLines.length - 1;
+              1 <= namePropDescriptor &&
+              0 <= _RunInRootFrame$Deter &&
+              sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter];
+
+            )
+              _RunInRootFrame$Deter--;
+          for (
+            ;
+            1 <= namePropDescriptor && 0 <= _RunInRootFrame$Deter;
+            namePropDescriptor--, _RunInRootFrame$Deter--
+          )
+            if (sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter]) {
+              if (1 !== namePropDescriptor || 1 !== _RunInRootFrame$Deter) {
+                do
+                  if (
+                    (namePropDescriptor--,
+                    _RunInRootFrame$Deter--,
+                    0 > _RunInRootFrame$Deter ||
+                      sampleLines[namePropDescriptor] !== controlLines[_RunInRootFrame$Deter])
+                  ) {
+                    var _frame = '\n' + sampleLines[namePropDescriptor].replace(' at new ', ' at ');
+                    fn.displayName &&
+                      _frame.includes('<anonymous>') &&
+                      (_frame = _frame.replace('<anonymous>', fn.displayName));
+                    'function' === typeof fn && componentFrameCache.set(fn, _frame);
+                    return _frame;
+                  }
+                while (1 <= namePropDescriptor && 0 <= _RunInRootFrame$Deter);
+              }
+              break;
+            }
+        }
+      } finally {
+        (reentry = !1),
+          (ReactSharedInternals.H = previousDispatcher),
+          reenableLogs(),
+          (Error.prepareStackTrace = frame);
+      }
+      sampleLines = (sampleLines = fn ? fn.displayName || fn.name : '')
+        ? describeBuiltInComponentFrame(sampleLines)
+        : '';
+      'function' === typeof fn && componentFrameCache.set(fn, sampleLines);
+      return sampleLines;
+    }
+    function describeUnknownElementTypeFrameInDEV(type) {
+      if (null == type) return '';
+      if ('function' === typeof type) {
+        var prototype = type.prototype;
+        return describeNativeComponentFrame(type, !(!prototype || !prototype.isReactComponent));
+      }
+      if ('string' === typeof type) return describeBuiltInComponentFrame(type);
+      switch (type) {
+        case REACT_SUSPENSE_TYPE:
+          return describeBuiltInComponentFrame('Suspense');
+        case REACT_SUSPENSE_LIST_TYPE:
+          return describeBuiltInComponentFrame('SuspenseList');
+      }
+      if ('object' === typeof type)
+        switch (type.$$typeof) {
+          case REACT_FORWARD_REF_TYPE:
+            return (type = describeNativeComponentFrame(type.render, !1)), type;
+          case REACT_MEMO_TYPE:
+            return describeUnknownElementTypeFrameInDEV(type.type);
+          case REACT_LAZY_TYPE:
+            prototype = type._payload;
+            type = type._init;
+            try {
+              return describeUnknownElementTypeFrameInDEV(type(prototype));
+            } catch (x) {}
+        }
+      return '';
+    }
+    function getOwner() {
+      var dispatcher = ReactSharedInternals.A;
+      return null === dispatcher ? null : dispatcher.getOwner();
+    }
+    function hasValidKey(config) {
+      if (hasOwnProperty.call(config, 'key')) {
+        var getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+        if (getter && getter.isReactWarning) return !1;
+      }
+      return void 0 !== config.key;
+    }
+    function defineKeyPropWarningGetter(props, displayName) {
+      function warnAboutAccessingKey() {
+        specialPropKeyWarningShown ||
+          ((specialPropKeyWarningShown = !0),
+          console.error(
+            '%s: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://react.dev/link/special-props)',
+            displayName,
+          ));
+      }
+      warnAboutAccessingKey.isReactWarning = !0;
+      Object.defineProperty(props, 'key', {
+        get: warnAboutAccessingKey,
+        configurable: !0,
+      });
+    }
+    function elementRefGetterWithDeprecationWarning() {
+      var componentName = getComponentNameFromType(this.type);
+      didWarnAboutElementRef[componentName] ||
+        ((didWarnAboutElementRef[componentName] = !0),
+        console.error(
+          'Accessing element.ref was removed in React 19. ref is now a regular prop. It will be removed from the JSX Element type in a future release.',
+        ));
+      componentName = this.props.ref;
+      return void 0 !== componentName ? componentName : null;
+    }
+    function ReactElement(type, key, self, source, owner, props) {
+      self = props.ref;
+      const { Platform } = require('react-native');
+      const SUPPORTED_FS_ATTRIBUTES = [
+        'fsClass',
+        'fsAttribute',
+        'fsTagName',
+        'dataElement',
+        'dataComponent',
+        'dataSourceFile',
+      ];
+      const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+      if (isTurboModuleEnabled && Platform.OS === 'ios') {
+        if (
+          type.$$typeof &&
+          (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
+            type.$$typeof.toString() === 'Symbol(react.element)' ||
+            type.$$typeof.toString() === 'Symbol(react.transitional.element)')
+        ) {
+          if (props) {
+            const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+              return typeof props[fsAttribute] === 'string' && !!props[fsAttribute];
+            });
+            if (propContainsFSAttribute) {
+              const fs = require('@fullstory/react-native');
+              props = {
+                ...props,
+                ref: fs.applyFSPropertiesWithRef(props['ref']),
+              };
+            }
+          }
+        }
+      }
+      type = {
+        $$typeof: REACT_ELEMENT_TYPE,
+        type: type,
+        key: key,
+        props: props,
+        _owner: owner,
+      };
+      null !== (void 0 !== self ? self : null)
+        ? Object.defineProperty(type, 'ref', {
+            enumerable: !1,
+            get: elementRefGetterWithDeprecationWarning,
+          })
+        : Object.defineProperty(type, 'ref', {
+            enumerable: !1,
+            value: null,
+          });
+      type._store = {};
+      Object.defineProperty(type._store, 'validated', {
+        configurable: !1,
+        enumerable: !1,
+        writable: !0,
+        value: 0,
+      });
+      Object.defineProperty(type, '_debugInfo', {
+        configurable: !1,
+        enumerable: !1,
+        writable: !0,
+        value: null,
+      });
+      Object.freeze && (Object.freeze(type.props), Object.freeze(type));
+      return type;
+    }
+    function jsxDEVImpl(type, config, maybeKey, isStaticChildren, source, self) {
+      if (
+        'string' === typeof type ||
+        'function' === typeof type ||
+        type === REACT_FRAGMENT_TYPE ||
+        type === REACT_PROFILER_TYPE ||
+        type === REACT_STRICT_MODE_TYPE ||
+        type === REACT_SUSPENSE_TYPE ||
+        type === REACT_SUSPENSE_LIST_TYPE ||
+        type === REACT_OFFSCREEN_TYPE ||
+        ('object' === typeof type &&
+          null !== type &&
+          (type.$$typeof === REACT_LAZY_TYPE ||
+            type.$$typeof === REACT_MEMO_TYPE ||
+            type.$$typeof === REACT_CONTEXT_TYPE ||
+            type.$$typeof === REACT_CONSUMER_TYPE ||
+            type.$$typeof === REACT_FORWARD_REF_TYPE ||
+            type.$$typeof === REACT_CLIENT_REFERENCE$1 ||
+            void 0 !== type.getModuleId))
+      ) {
+        var children = config.children;
+        if (void 0 !== children)
+          if (isStaticChildren) {
+            if (isArrayImpl(children)) {
+              for (isStaticChildren = 0; isStaticChildren < children.length; isStaticChildren++)
+                validateChildKeys(children[isStaticChildren], type);
+              Object.freeze && Object.freeze(children);
+            } else
+              console.error(
+                'React.jsx: Static children should always be an array. You are likely explicitly calling React.jsxs or React.jsxDEV. Use the Babel transform instead.',
+              );
+          } else validateChildKeys(children, type);
+      } else {
+        children = '';
+        if (
+          void 0 === type ||
+          ('object' === typeof type && null !== type && 0 === Object.keys(type).length)
+        )
+          children +=
+            " You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.";
+        null === type
+          ? (isStaticChildren = 'null')
+          : isArrayImpl(type)
+          ? (isStaticChildren = 'array')
+          : void 0 !== type && type.$$typeof === REACT_ELEMENT_TYPE
+          ? ((isStaticChildren = '<' + (getComponentNameFromType(type.type) || 'Unknown') + ' />'),
+            (children = ' Did you accidentally export a JSX literal instead of a component?'))
+          : (isStaticChildren = typeof type);
+        console.error(
+          'React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s',
+          isStaticChildren,
+          children,
+        );
+      }
+      if (hasOwnProperty.call(config, 'key')) {
+        children = getComponentNameFromType(type);
+        var keys = Object.keys(config).filter(function (k) {
+          return 'key' !== k;
+        });
+        isStaticChildren =
+          0 < keys.length ? '{key: someKey, ' + keys.join(': ..., ') + ': ...}' : '{key: someKey}';
+        didWarnAboutKeySpread[children + isStaticChildren] ||
+          ((keys = 0 < keys.length ? '{' + keys.join(': ..., ') + ': ...}' : '{}'),
+          console.error(
+            'A props object containing a "key" prop is being spread into JSX:\n  let props = %s;\n  <%s {...props} />\nReact keys must be passed directly to JSX without using spread:\n  let props = %s;\n  <%s key={someKey} {...props} />',
+            isStaticChildren,
+            children,
+            keys,
+            children,
+          ),
+          (didWarnAboutKeySpread[children + isStaticChildren] = !0));
+      }
+      children = null;
+      void 0 !== maybeKey && (checkKeyStringCoercion(maybeKey), (children = '' + maybeKey));
+      hasValidKey(config) && (checkKeyStringCoercion(config.key), (children = '' + config.key));
+      if ('key' in config) {
+        maybeKey = {};
+        for (var propName in config) 'key' !== propName && (maybeKey[propName] = config[propName]);
+      } else maybeKey = config;
+      children &&
+        defineKeyPropWarningGetter(
+          maybeKey,
+          'function' === typeof type ? type.displayName || type.name || 'Unknown' : type,
+        );
+      return ReactElement(type, children, self, source, getOwner(), maybeKey);
+    }
+    function validateChildKeys(node, parentType) {
+      if ('object' === typeof node && node && node.$$typeof !== REACT_CLIENT_REFERENCE)
+        if (isArrayImpl(node))
+          for (var i = 0; i < node.length; i++) {
+            var child = node[i];
+            isValidElement(child) && validateExplicitKey(child, parentType);
+          }
+        else if (isValidElement(node)) node._store && (node._store.validated = 1);
+        else if (
+          (null === node || 'object' !== typeof node
+            ? (i = null)
+            : ((i = (MAYBE_ITERATOR_SYMBOL && node[MAYBE_ITERATOR_SYMBOL]) || node['@@iterator']),
+              (i = 'function' === typeof i ? i : null)),
+          'function' === typeof i && i !== node.entries && ((i = i.call(node)), i !== node))
+        )
+          for (; !(node = i.next()).done; )
+            isValidElement(node.value) && validateExplicitKey(node.value, parentType);
+    }
+    function isValidElement(object) {
+      return (
+        'object' === typeof object && null !== object && object.$$typeof === REACT_ELEMENT_TYPE
+      );
+    }
+    function validateExplicitKey(element, parentType) {
+      if (
+        element._store &&
+        !element._store.validated &&
+        null == element.key &&
+        ((element._store.validated = 1),
+        (parentType = getCurrentComponentErrorInfo(parentType)),
+        !ownerHasKeyUseWarning[parentType])
+      ) {
+        ownerHasKeyUseWarning[parentType] = !0;
+        var childOwner = '';
+        element &&
+          null != element._owner &&
+          element._owner !== getOwner() &&
+          ((childOwner = null),
+          'number' === typeof element._owner.tag
+            ? (childOwner = getComponentNameFromType(element._owner.type))
+            : 'string' === typeof element._owner.name && (childOwner = element._owner.name),
+          (childOwner = ' It was passed a child from ' + childOwner + '.'));
+        var prevGetCurrentStack = ReactSharedInternals.getCurrentStack;
+        ReactSharedInternals.getCurrentStack = function () {
+          var stack = describeUnknownElementTypeFrameInDEV(element.type);
+          prevGetCurrentStack && (stack += prevGetCurrentStack() || '');
+          return stack;
+        };
+        console.error(
+          'Each child in a list should have a unique "key" prop.%s%s See https://react.dev/link/warning-keys for more information.',
+          parentType,
+          childOwner,
+        );
+        ReactSharedInternals.getCurrentStack = prevGetCurrentStack;
+      }
+    }
+    function getCurrentComponentErrorInfo(parentType) {
+      var info = '',
+        owner = getOwner();
+      owner &&
+        (owner = getComponentNameFromType(owner.type)) &&
+        (info = '\n\nCheck the render method of `' + owner + '`.');
+      info ||
+        ((parentType = getComponentNameFromType(parentType)) &&
+          (info = '\n\nCheck the top-level render call using <' + parentType + '>.'));
+      return info;
+    }
+    var React = require('react'),
+      REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
+      REACT_PORTAL_TYPE = Symbol.for('react.portal'),
+      REACT_FRAGMENT_TYPE = Symbol.for('react.fragment'),
+      REACT_STRICT_MODE_TYPE = Symbol.for('react.strict_mode'),
+      REACT_PROFILER_TYPE = Symbol.for('react.profiler');
+    Symbol.for('react.provider');
+    var REACT_CONSUMER_TYPE = Symbol.for('react.consumer'),
+      REACT_CONTEXT_TYPE = Symbol.for('react.context'),
+      REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref'),
+      REACT_SUSPENSE_TYPE = Symbol.for('react.suspense'),
+      REACT_SUSPENSE_LIST_TYPE = Symbol.for('react.suspense_list'),
+      REACT_MEMO_TYPE = Symbol.for('react.memo'),
+      REACT_LAZY_TYPE = Symbol.for('react.lazy'),
+      REACT_OFFSCREEN_TYPE = Symbol.for('react.offscreen'),
+      MAYBE_ITERATOR_SYMBOL = Symbol.iterator,
+      REACT_CLIENT_REFERENCE$2 = Symbol.for('react.client.reference'),
+      ReactSharedInternals = React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
+      hasOwnProperty = Object.prototype.hasOwnProperty,
+      assign = Object.assign,
+      REACT_CLIENT_REFERENCE$1 = Symbol.for('react.client.reference'),
+      isArrayImpl = Array.isArray,
+      disabledDepth = 0,
+      prevLog,
+      prevInfo,
+      prevWarn,
+      prevError,
+      prevGroup,
+      prevGroupCollapsed,
+      prevGroupEnd;
+    disabledLog.__reactDisabledLog = !0;
+    var prefix,
+      suffix,
+      reentry = !1;
+    var componentFrameCache = new ('function' === typeof WeakMap ? WeakMap : Map)();
+    var REACT_CLIENT_REFERENCE = Symbol.for('react.client.reference'),
+      specialPropKeyWarningShown;
+    var didWarnAboutElementRef = {};
+    var didWarnAboutKeySpread = {},
+      ownerHasKeyUseWarning = {};
+    exports.Fragment = REACT_FRAGMENT_TYPE;
+    exports.jsx = function (type, config, maybeKey, source, self) {
+      return jsxDEVImpl(type, config, maybeKey, !1, source, self);
+    };
+    exports.jsxs = function (type, config, maybeKey, source, self) {
+      return jsxDEVImpl(type, config, maybeKey, !0, source, self);
+    };
+  })();

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
@@ -44,7 +44,8 @@ function q(c, a, g) {
     if (
       c.$$typeof &&
       (c.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-        c.$$typeof.toString() === 'Symbol(react.element)')
+        c.$$typeof.toString() === 'Symbol(react.element)' ||
+        c.$$typeof.toString() === 'Symbol(react.transitional.element)')
     ) {
       if (d) {
         const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/code.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/code.js
@@ -1,0 +1,33 @@
+/**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+var REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
+  REACT_FRAGMENT_TYPE = Symbol.for('react.fragment');
+function jsxProd(type, config, maybeKey) {
+  var key = null;
+  void 0 !== maybeKey && (key = '' + maybeKey);
+  void 0 !== config.key && (key = '' + config.key);
+  if ('key' in config) {
+    maybeKey = {};
+    for (var propName in config) 'key' !== propName && (maybeKey[propName] = config[propName]);
+  } else maybeKey = config;
+  config = maybeKey.ref;
+  return {
+    $$typeof: REACT_ELEMENT_TYPE,
+    type: type,
+    key: key,
+    ref: void 0 !== config ? config : null,
+    props: maybeKey,
+  };
+}
+exports.Fragment = REACT_FRAGMENT_TYPE;
+exports.jsx = jsxProd;
+exports.jsxs = jsxProd;

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/options.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/options.js
@@ -1,0 +1,10 @@
+import * as path from 'path';
+
+module.exports = {
+  babelOptions: {
+    filename: path.join(
+      __dirname,
+      'ReactNativeNewArch/node_modules/react/cjs/react-jsx-runtime.production.js',
+    ),
+  },
+};

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
@@ -1,0 +1,65 @@
+/**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+var REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
+  REACT_FRAGMENT_TYPE = Symbol.for('react.fragment');
+function jsxProd(type, config, maybeKey) {
+  var key = null;
+  void 0 !== maybeKey && (key = '' + maybeKey);
+  void 0 !== config.key && (key = '' + config.key);
+  if ('key' in config) {
+    maybeKey = {};
+    for (var propName in config) 'key' !== propName && (maybeKey[propName] = config[propName]);
+  } else maybeKey = config;
+  config = maybeKey.ref;
+  const { Platform } = require('react-native');
+  const SUPPORTED_FS_ATTRIBUTES = [
+    'fsClass',
+    'fsAttribute',
+    'fsTagName',
+    'dataElement',
+    'dataComponent',
+    'dataSourceFile',
+  ];
+  const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+  if (isTurboModuleEnabled && Platform.OS === 'ios') {
+    if (
+      type.$$typeof &&
+      (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
+        type.$$typeof.toString() === 'Symbol(react.element)' ||
+        type.$$typeof.toString() === 'Symbol(react.transitional.element)')
+    ) {
+      if (maybeKey) {
+        const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+          return typeof maybeKey[fsAttribute] === 'string' && !!maybeKey[fsAttribute];
+        });
+        if (propContainsFSAttribute) {
+          const fs = require('@fullstory/react-native');
+          maybeKey = {
+            ...maybeKey,
+            ref: fs.applyFSPropertiesWithRef(maybeKey['ref']),
+          };
+        }
+      }
+    }
+  }
+  return {
+    $$typeof: REACT_ELEMENT_TYPE,
+    type: type,
+    key: key,
+    ref: void 0 !== config ? config : null,
+    props: maybeKey,
+  };
+}
+exports.Fragment = REACT_FRAGMENT_TYPE;
+exports.jsx = jsxProd;
+exports.jsxs = jsxProd;

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
@@ -105,7 +105,8 @@ function M(a, b, e) {
     if (
       a.$$typeof &&
       (a.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-        a.$$typeof.toString() === 'Symbol(react.element)')
+        a.$$typeof.toString() === 'Symbol(react.element)' ||
+        a.$$typeof.toString() === 'Symbol(react.transitional.element)')
     ) {
       if (c) {
         const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
@@ -331,7 +332,8 @@ exports.cloneElement = function (a, b, e) {
     if (
       a.$$typeof &&
       (a.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-        a.$$typeof.toString() === 'Symbol(react.element)')
+        a.$$typeof.toString() === 'Symbol(react.element)' ||
+        a.$$typeof.toString() === 'Symbol(react.transitional.element)')
     ) {
       if (d) {
         const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/code.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/code.js
@@ -1,0 +1,474 @@
+/**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+var REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
+  REACT_PORTAL_TYPE = Symbol.for('react.portal'),
+  REACT_FRAGMENT_TYPE = Symbol.for('react.fragment'),
+  REACT_STRICT_MODE_TYPE = Symbol.for('react.strict_mode'),
+  REACT_PROFILER_TYPE = Symbol.for('react.profiler'),
+  REACT_CONSUMER_TYPE = Symbol.for('react.consumer'),
+  REACT_CONTEXT_TYPE = Symbol.for('react.context'),
+  REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref'),
+  REACT_SUSPENSE_TYPE = Symbol.for('react.suspense'),
+  REACT_MEMO_TYPE = Symbol.for('react.memo'),
+  REACT_LAZY_TYPE = Symbol.for('react.lazy'),
+  MAYBE_ITERATOR_SYMBOL = Symbol.iterator;
+function getIteratorFn(maybeIterable) {
+  if (null === maybeIterable || 'object' !== typeof maybeIterable) return null;
+  maybeIterable =
+    (MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL]) || maybeIterable['@@iterator'];
+  return 'function' === typeof maybeIterable ? maybeIterable : null;
+}
+var ReactNoopUpdateQueue = {
+    isMounted: function () {
+      return !1;
+    },
+    enqueueForceUpdate: function () {},
+    enqueueReplaceState: function () {},
+    enqueueSetState: function () {},
+  },
+  assign = Object.assign,
+  emptyObject = {};
+function Component(props, context, updater) {
+  this.props = props;
+  this.context = context;
+  this.refs = emptyObject;
+  this.updater = updater || ReactNoopUpdateQueue;
+}
+Component.prototype.isReactComponent = {};
+Component.prototype.setState = function (partialState, callback) {
+  if (
+    'object' !== typeof partialState &&
+    'function' !== typeof partialState &&
+    null != partialState
+  )
+    throw Error(
+      'takes an object of state variables to update or a function which returns an object of state variables.',
+    );
+  this.updater.enqueueSetState(this, partialState, callback, 'setState');
+};
+Component.prototype.forceUpdate = function (callback) {
+  this.updater.enqueueForceUpdate(this, callback, 'forceUpdate');
+};
+function ComponentDummy() {}
+ComponentDummy.prototype = Component.prototype;
+function PureComponent(props, context, updater) {
+  this.props = props;
+  this.context = context;
+  this.refs = emptyObject;
+  this.updater = updater || ReactNoopUpdateQueue;
+}
+var pureComponentPrototype = (PureComponent.prototype = new ComponentDummy());
+pureComponentPrototype.constructor = PureComponent;
+assign(pureComponentPrototype, Component.prototype);
+pureComponentPrototype.isPureReactComponent = !0;
+var isArrayImpl = Array.isArray,
+  ReactSharedInternals = { H: null, A: null, T: null, S: null },
+  hasOwnProperty = Object.prototype.hasOwnProperty;
+function ReactElement(type, key, self, source, owner, props) {
+  self = props.ref;
+  return {
+    $$typeof: REACT_ELEMENT_TYPE,
+    type: type,
+    key: key,
+    ref: void 0 !== self ? self : null,
+    props: props,
+  };
+}
+function cloneAndReplaceKey(oldElement, newKey) {
+  return ReactElement(oldElement.type, newKey, void 0, void 0, void 0, oldElement.props);
+}
+function isValidElement(object) {
+  return 'object' === typeof object && null !== object && object.$$typeof === REACT_ELEMENT_TYPE;
+}
+function escape(key) {
+  var escaperLookup = { '=': '=0', ':': '=2' };
+  return (
+    '$' +
+    key.replace(/[=:]/g, function (match) {
+      return escaperLookup[match];
+    })
+  );
+}
+var userProvidedKeyEscapeRegex = /\/+/g;
+function getElementKey(element, index) {
+  return 'object' === typeof element && null !== element && null != element.key
+    ? escape('' + element.key)
+    : index.toString(36);
+}
+function noop$1() {}
+function resolveThenable(thenable) {
+  switch (thenable.status) {
+    case 'fulfilled':
+      return thenable.value;
+    case 'rejected':
+      throw thenable.reason;
+    default:
+      switch (
+        ('string' === typeof thenable.status
+          ? thenable.then(noop$1, noop$1)
+          : ((thenable.status = 'pending'),
+            thenable.then(
+              function (fulfilledValue) {
+                'pending' === thenable.status &&
+                  ((thenable.status = 'fulfilled'), (thenable.value = fulfilledValue));
+              },
+              function (error) {
+                'pending' === thenable.status &&
+                  ((thenable.status = 'rejected'), (thenable.reason = error));
+              },
+            )),
+        thenable.status)
+      ) {
+        case 'fulfilled':
+          return thenable.value;
+        case 'rejected':
+          throw thenable.reason;
+      }
+  }
+  throw thenable;
+}
+function mapIntoArray(children, array, escapedPrefix, nameSoFar, callback) {
+  var type = typeof children;
+  if ('undefined' === type || 'boolean' === type) children = null;
+  var invokeCallback = !1;
+  if (null === children) invokeCallback = !0;
+  else
+    switch (type) {
+      case 'bigint':
+      case 'string':
+      case 'number':
+        invokeCallback = !0;
+        break;
+      case 'object':
+        switch (children.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+          case REACT_PORTAL_TYPE:
+            invokeCallback = !0;
+            break;
+          case REACT_LAZY_TYPE:
+            return (
+              (invokeCallback = children._init),
+              mapIntoArray(
+                invokeCallback(children._payload),
+                array,
+                escapedPrefix,
+                nameSoFar,
+                callback,
+              )
+            );
+        }
+    }
+  if (invokeCallback)
+    return (
+      (callback = callback(children)),
+      (invokeCallback = '' === nameSoFar ? '.' + getElementKey(children, 0) : nameSoFar),
+      isArrayImpl(callback)
+        ? ((escapedPrefix = ''),
+          null != invokeCallback &&
+            (escapedPrefix = invokeCallback.replace(userProvidedKeyEscapeRegex, '$&/') + '/'),
+          mapIntoArray(callback, array, escapedPrefix, '', function (c) {
+            return c;
+          }))
+        : null != callback &&
+          (isValidElement(callback) &&
+            (callback = cloneAndReplaceKey(
+              callback,
+              escapedPrefix +
+                (null == callback.key || (children && children.key === callback.key)
+                  ? ''
+                  : ('' + callback.key).replace(userProvidedKeyEscapeRegex, '$&/') + '/') +
+                invokeCallback,
+            )),
+          array.push(callback)),
+      1
+    );
+  invokeCallback = 0;
+  var nextNamePrefix = '' === nameSoFar ? '.' : nameSoFar + ':';
+  if (isArrayImpl(children))
+    for (var i = 0; i < children.length; i++)
+      (nameSoFar = children[i]),
+        (type = nextNamePrefix + getElementKey(nameSoFar, i)),
+        (invokeCallback += mapIntoArray(nameSoFar, array, escapedPrefix, type, callback));
+  else if (((i = getIteratorFn(children)), 'function' === typeof i))
+    for (children = i.call(children), i = 0; !(nameSoFar = children.next()).done; )
+      (nameSoFar = nameSoFar.value),
+        (type = nextNamePrefix + getElementKey(nameSoFar, i++)),
+        (invokeCallback += mapIntoArray(nameSoFar, array, escapedPrefix, type, callback));
+  else if ('object' === type) {
+    if ('function' === typeof children.then)
+      return mapIntoArray(resolveThenable(children), array, escapedPrefix, nameSoFar, callback);
+    array = String(children);
+    throw Error(
+      'Objects are not valid as a React child (found: ' +
+        ('[object Object]' === array
+          ? 'object with keys {' + Object.keys(children).join(', ') + '}'
+          : array) +
+        '). If you meant to render a collection of children, use an array instead.',
+    );
+  }
+  return invokeCallback;
+}
+function mapChildren(children, func, context) {
+  if (null == children) return children;
+  var result = [],
+    count = 0;
+  mapIntoArray(children, result, '', '', function (child) {
+    return func.call(context, child, count++);
+  });
+  return result;
+}
+function lazyInitializer(payload) {
+  if (-1 === payload._status) {
+    var ctor = payload._result;
+    ctor = ctor();
+    ctor.then(
+      function (moduleObject) {
+        if (0 === payload._status || -1 === payload._status)
+          (payload._status = 1), (payload._result = moduleObject);
+      },
+      function (error) {
+        if (0 === payload._status || -1 === payload._status)
+          (payload._status = 2), (payload._result = error);
+      },
+    );
+    -1 === payload._status && ((payload._status = 0), (payload._result = ctor));
+  }
+  if (1 === payload._status) return payload._result.default;
+  throw payload._result;
+}
+var reportGlobalError =
+  'function' === typeof reportError
+    ? reportError
+    : function (error) {
+        if ('object' === typeof window && 'function' === typeof window.ErrorEvent) {
+          var event = new window.ErrorEvent('error', {
+            bubbles: !0,
+            cancelable: !0,
+            message:
+              'object' === typeof error && null !== error && 'string' === typeof error.message
+                ? String(error.message)
+                : String(error),
+            error: error,
+          });
+          if (!window.dispatchEvent(event)) return;
+        } else if ('object' === typeof process && 'function' === typeof process.emit) {
+          process.emit('uncaughtException', error);
+          return;
+        }
+        console.error(error);
+      };
+function noop() {}
+exports.Children = {
+  map: mapChildren,
+  forEach: function (children, forEachFunc, forEachContext) {
+    mapChildren(
+      children,
+      function () {
+        forEachFunc.apply(this, arguments);
+      },
+      forEachContext,
+    );
+  },
+  count: function (children) {
+    var n = 0;
+    mapChildren(children, function () {
+      n++;
+    });
+    return n;
+  },
+  toArray: function (children) {
+    return (
+      mapChildren(children, function (child) {
+        return child;
+      }) || []
+    );
+  },
+  only: function (children) {
+    if (!isValidElement(children))
+      throw Error('React.Children.only expected to receive a single React element child.');
+    return children;
+  },
+};
+exports.Component = Component;
+exports.Fragment = REACT_FRAGMENT_TYPE;
+exports.Profiler = REACT_PROFILER_TYPE;
+exports.PureComponent = PureComponent;
+exports.StrictMode = REACT_STRICT_MODE_TYPE;
+exports.Suspense = REACT_SUSPENSE_TYPE;
+exports.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = ReactSharedInternals;
+exports.act = function () {
+  throw Error('act(...) is not supported in production builds of React.');
+};
+exports.cache = function (fn) {
+  return function () {
+    return fn.apply(null, arguments);
+  };
+};
+exports.cloneElement = function (element, config, children) {
+  if (null === element || void 0 === element)
+    throw Error('The argument must be a React element, but you passed ' + element + '.');
+  var props = assign({}, element.props),
+    key = element.key,
+    owner = void 0;
+  if (null != config)
+    for (propName in (void 0 !== config.ref && (owner = void 0),
+    void 0 !== config.key && (key = '' + config.key),
+    config))
+      !hasOwnProperty.call(config, propName) ||
+        'key' === propName ||
+        '__self' === propName ||
+        '__source' === propName ||
+        ('ref' === propName && void 0 === config.ref) ||
+        (props[propName] = config[propName]);
+  var propName = arguments.length - 2;
+  if (1 === propName) props.children = children;
+  else if (1 < propName) {
+    for (var childArray = Array(propName), i = 0; i < propName; i++)
+      childArray[i] = arguments[i + 2];
+    props.children = childArray;
+  }
+  return ReactElement(element.type, key, void 0, void 0, owner, props);
+};
+exports.createContext = function (defaultValue) {
+  defaultValue = {
+    $$typeof: REACT_CONTEXT_TYPE,
+    _currentValue: defaultValue,
+    _currentValue2: defaultValue,
+    _threadCount: 0,
+    Provider: null,
+    Consumer: null,
+  };
+  defaultValue.Provider = defaultValue;
+  defaultValue.Consumer = {
+    $$typeof: REACT_CONSUMER_TYPE,
+    _context: defaultValue,
+  };
+  return defaultValue;
+};
+exports.createElement = function (type, config, children) {
+  var propName,
+    props = {},
+    key = null;
+  if (null != config)
+    for (propName in (void 0 !== config.key && (key = '' + config.key), config))
+      hasOwnProperty.call(config, propName) &&
+        'key' !== propName &&
+        '__self' !== propName &&
+        '__source' !== propName &&
+        (props[propName] = config[propName]);
+  var childrenLength = arguments.length - 2;
+  if (1 === childrenLength) props.children = children;
+  else if (1 < childrenLength) {
+    for (var childArray = Array(childrenLength), i = 0; i < childrenLength; i++)
+      childArray[i] = arguments[i + 2];
+    props.children = childArray;
+  }
+  if (type && type.defaultProps)
+    for (propName in ((childrenLength = type.defaultProps), childrenLength))
+      void 0 === props[propName] && (props[propName] = childrenLength[propName]);
+  return ReactElement(type, key, void 0, void 0, null, props);
+};
+exports.createRef = function () {
+  return { current: null };
+};
+exports.forwardRef = function (render) {
+  return { $$typeof: REACT_FORWARD_REF_TYPE, render: render };
+};
+exports.isValidElement = isValidElement;
+exports.lazy = function (ctor) {
+  return {
+    $$typeof: REACT_LAZY_TYPE,
+    _payload: { _status: -1, _result: ctor },
+    _init: lazyInitializer,
+  };
+};
+exports.memo = function (type, compare) {
+  return {
+    $$typeof: REACT_MEMO_TYPE,
+    type: type,
+    compare: void 0 === compare ? null : compare,
+  };
+};
+exports.startTransition = function (scope) {
+  var prevTransition = ReactSharedInternals.T,
+    currentTransition = {};
+  ReactSharedInternals.T = currentTransition;
+  try {
+    var returnValue = scope(),
+      onStartTransitionFinish = ReactSharedInternals.S;
+    null !== onStartTransitionFinish && onStartTransitionFinish(currentTransition, returnValue);
+    'object' === typeof returnValue &&
+      null !== returnValue &&
+      'function' === typeof returnValue.then &&
+      returnValue.then(noop, reportGlobalError);
+  } catch (error) {
+    reportGlobalError(error);
+  } finally {
+    ReactSharedInternals.T = prevTransition;
+  }
+};
+exports.unstable_useCacheRefresh = function () {
+  return ReactSharedInternals.H.useCacheRefresh();
+};
+exports.use = function (usable) {
+  return ReactSharedInternals.H.use(usable);
+};
+exports.useActionState = function (action, initialState, permalink) {
+  return ReactSharedInternals.H.useActionState(action, initialState, permalink);
+};
+exports.useCallback = function (callback, deps) {
+  return ReactSharedInternals.H.useCallback(callback, deps);
+};
+exports.useContext = function (Context) {
+  return ReactSharedInternals.H.useContext(Context);
+};
+exports.useDebugValue = function () {};
+exports.useDeferredValue = function (value, initialValue) {
+  return ReactSharedInternals.H.useDeferredValue(value, initialValue);
+};
+exports.useEffect = function (create, deps) {
+  return ReactSharedInternals.H.useEffect(create, deps);
+};
+exports.useId = function () {
+  return ReactSharedInternals.H.useId();
+};
+exports.useImperativeHandle = function (ref, create, deps) {
+  return ReactSharedInternals.H.useImperativeHandle(ref, create, deps);
+};
+exports.useInsertionEffect = function (create, deps) {
+  return ReactSharedInternals.H.useInsertionEffect(create, deps);
+};
+exports.useLayoutEffect = function (create, deps) {
+  return ReactSharedInternals.H.useLayoutEffect(create, deps);
+};
+exports.useMemo = function (create, deps) {
+  return ReactSharedInternals.H.useMemo(create, deps);
+};
+exports.useOptimistic = function (passthrough, reducer) {
+  return ReactSharedInternals.H.useOptimistic(passthrough, reducer);
+};
+exports.useReducer = function (reducer, initialArg, init) {
+  return ReactSharedInternals.H.useReducer(reducer, initialArg, init);
+};
+exports.useRef = function (initialValue) {
+  return ReactSharedInternals.H.useRef(initialValue);
+};
+exports.useState = function (initialState) {
+  return ReactSharedInternals.H.useState(initialState);
+};
+exports.useSyncExternalStore = function (subscribe, getSnapshot, getServerSnapshot) {
+  return ReactSharedInternals.H.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+};
+exports.useTransition = function () {
+  return ReactSharedInternals.H.useTransition();
+};
+exports.version = '19.0.0';

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/options.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/options.js
@@ -1,0 +1,7 @@
+import * as path from 'path';
+
+module.exports = {
+  babelOptions: {
+    filename: path.join(__dirname, 'ReactNativeNewArch/node_modules/react/cjs/react.production.js'),
+  },
+};

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
@@ -1,0 +1,522 @@
+/**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+var REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
+  REACT_PORTAL_TYPE = Symbol.for('react.portal'),
+  REACT_FRAGMENT_TYPE = Symbol.for('react.fragment'),
+  REACT_STRICT_MODE_TYPE = Symbol.for('react.strict_mode'),
+  REACT_PROFILER_TYPE = Symbol.for('react.profiler'),
+  REACT_CONSUMER_TYPE = Symbol.for('react.consumer'),
+  REACT_CONTEXT_TYPE = Symbol.for('react.context'),
+  REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref'),
+  REACT_SUSPENSE_TYPE = Symbol.for('react.suspense'),
+  REACT_MEMO_TYPE = Symbol.for('react.memo'),
+  REACT_LAZY_TYPE = Symbol.for('react.lazy'),
+  MAYBE_ITERATOR_SYMBOL = Symbol.iterator;
+function getIteratorFn(maybeIterable) {
+  if (null === maybeIterable || 'object' !== typeof maybeIterable) return null;
+  maybeIterable =
+    (MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL]) || maybeIterable['@@iterator'];
+  return 'function' === typeof maybeIterable ? maybeIterable : null;
+}
+var ReactNoopUpdateQueue = {
+    isMounted: function () {
+      return !1;
+    },
+    enqueueForceUpdate: function () {},
+    enqueueReplaceState: function () {},
+    enqueueSetState: function () {},
+  },
+  assign = Object.assign,
+  emptyObject = {};
+function Component(props, context, updater) {
+  this.props = props;
+  this.context = context;
+  this.refs = emptyObject;
+  this.updater = updater || ReactNoopUpdateQueue;
+}
+Component.prototype.isReactComponent = {};
+Component.prototype.setState = function (partialState, callback) {
+  if (
+    'object' !== typeof partialState &&
+    'function' !== typeof partialState &&
+    null != partialState
+  )
+    throw Error(
+      'takes an object of state variables to update or a function which returns an object of state variables.',
+    );
+  this.updater.enqueueSetState(this, partialState, callback, 'setState');
+};
+Component.prototype.forceUpdate = function (callback) {
+  this.updater.enqueueForceUpdate(this, callback, 'forceUpdate');
+};
+function ComponentDummy() {}
+ComponentDummy.prototype = Component.prototype;
+function PureComponent(props, context, updater) {
+  this.props = props;
+  this.context = context;
+  this.refs = emptyObject;
+  this.updater = updater || ReactNoopUpdateQueue;
+}
+var pureComponentPrototype = (PureComponent.prototype = new ComponentDummy());
+pureComponentPrototype.constructor = PureComponent;
+assign(pureComponentPrototype, Component.prototype);
+pureComponentPrototype.isPureReactComponent = !0;
+var isArrayImpl = Array.isArray,
+  ReactSharedInternals = {
+    H: null,
+    A: null,
+    T: null,
+    S: null,
+  },
+  hasOwnProperty = Object.prototype.hasOwnProperty;
+function ReactElement(type, key, self, source, owner, props) {
+  self = props.ref;
+  const { Platform } = require('react-native');
+  const SUPPORTED_FS_ATTRIBUTES = [
+    'fsClass',
+    'fsAttribute',
+    'fsTagName',
+    'dataElement',
+    'dataComponent',
+    'dataSourceFile',
+  ];
+  const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+  if (isTurboModuleEnabled && Platform.OS === 'ios') {
+    if (
+      type.$$typeof &&
+      (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
+        type.$$typeof.toString() === 'Symbol(react.element)' ||
+        type.$$typeof.toString() === 'Symbol(react.transitional.element)')
+    ) {
+      if (props) {
+        const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+          return typeof props[fsAttribute] === 'string' && !!props[fsAttribute];
+        });
+        if (propContainsFSAttribute) {
+          const fs = require('@fullstory/react-native');
+          props = {
+            ...props,
+            ref: fs.applyFSPropertiesWithRef(props['ref']),
+          };
+        }
+      }
+    }
+  }
+  return {
+    $$typeof: REACT_ELEMENT_TYPE,
+    type: type,
+    key: key,
+    ref: void 0 !== self ? self : null,
+    props: props,
+  };
+}
+function cloneAndReplaceKey(oldElement, newKey) {
+  return ReactElement(oldElement.type, newKey, void 0, void 0, void 0, oldElement.props);
+}
+function isValidElement(object) {
+  return 'object' === typeof object && null !== object && object.$$typeof === REACT_ELEMENT_TYPE;
+}
+function escape(key) {
+  var escaperLookup = {
+    '=': '=0',
+    ':': '=2',
+  };
+  return (
+    '$' +
+    key.replace(/[=:]/g, function (match) {
+      return escaperLookup[match];
+    })
+  );
+}
+var userProvidedKeyEscapeRegex = /\/+/g;
+function getElementKey(element, index) {
+  return 'object' === typeof element && null !== element && null != element.key
+    ? escape('' + element.key)
+    : index.toString(36);
+}
+function noop$1() {}
+function resolveThenable(thenable) {
+  switch (thenable.status) {
+    case 'fulfilled':
+      return thenable.value;
+    case 'rejected':
+      throw thenable.reason;
+    default:
+      switch (
+        ('string' === typeof thenable.status
+          ? thenable.then(noop$1, noop$1)
+          : ((thenable.status = 'pending'),
+            thenable.then(
+              function (fulfilledValue) {
+                'pending' === thenable.status &&
+                  ((thenable.status = 'fulfilled'), (thenable.value = fulfilledValue));
+              },
+              function (error) {
+                'pending' === thenable.status &&
+                  ((thenable.status = 'rejected'), (thenable.reason = error));
+              },
+            )),
+        thenable.status)
+      ) {
+        case 'fulfilled':
+          return thenable.value;
+        case 'rejected':
+          throw thenable.reason;
+      }
+  }
+  throw thenable;
+}
+function mapIntoArray(children, array, escapedPrefix, nameSoFar, callback) {
+  var type = typeof children;
+  if ('undefined' === type || 'boolean' === type) children = null;
+  var invokeCallback = !1;
+  if (null === children) invokeCallback = !0;
+  else
+    switch (type) {
+      case 'bigint':
+      case 'string':
+      case 'number':
+        invokeCallback = !0;
+        break;
+      case 'object':
+        switch (children.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+          case REACT_PORTAL_TYPE:
+            invokeCallback = !0;
+            break;
+          case REACT_LAZY_TYPE:
+            return (
+              (invokeCallback = children._init),
+              mapIntoArray(
+                invokeCallback(children._payload),
+                array,
+                escapedPrefix,
+                nameSoFar,
+                callback,
+              )
+            );
+        }
+    }
+  if (invokeCallback)
+    return (
+      (callback = callback(children)),
+      (invokeCallback = '' === nameSoFar ? '.' + getElementKey(children, 0) : nameSoFar),
+      isArrayImpl(callback)
+        ? ((escapedPrefix = ''),
+          null != invokeCallback &&
+            (escapedPrefix = invokeCallback.replace(userProvidedKeyEscapeRegex, '$&/') + '/'),
+          mapIntoArray(callback, array, escapedPrefix, '', function (c) {
+            return c;
+          }))
+        : null != callback &&
+          (isValidElement(callback) &&
+            (callback = cloneAndReplaceKey(
+              callback,
+              escapedPrefix +
+                (null == callback.key || (children && children.key === callback.key)
+                  ? ''
+                  : ('' + callback.key).replace(userProvidedKeyEscapeRegex, '$&/') + '/') +
+                invokeCallback,
+            )),
+          array.push(callback)),
+      1
+    );
+  invokeCallback = 0;
+  var nextNamePrefix = '' === nameSoFar ? '.' : nameSoFar + ':';
+  if (isArrayImpl(children))
+    for (var i = 0; i < children.length; i++)
+      (nameSoFar = children[i]),
+        (type = nextNamePrefix + getElementKey(nameSoFar, i)),
+        (invokeCallback += mapIntoArray(nameSoFar, array, escapedPrefix, type, callback));
+  else if (((i = getIteratorFn(children)), 'function' === typeof i))
+    for (children = i.call(children), i = 0; !(nameSoFar = children.next()).done; )
+      (nameSoFar = nameSoFar.value),
+        (type = nextNamePrefix + getElementKey(nameSoFar, i++)),
+        (invokeCallback += mapIntoArray(nameSoFar, array, escapedPrefix, type, callback));
+  else if ('object' === type) {
+    if ('function' === typeof children.then)
+      return mapIntoArray(resolveThenable(children), array, escapedPrefix, nameSoFar, callback);
+    array = String(children);
+    throw Error(
+      'Objects are not valid as a React child (found: ' +
+        ('[object Object]' === array
+          ? 'object with keys {' + Object.keys(children).join(', ') + '}'
+          : array) +
+        '). If you meant to render a collection of children, use an array instead.',
+    );
+  }
+  return invokeCallback;
+}
+function mapChildren(children, func, context) {
+  if (null == children) return children;
+  var result = [],
+    count = 0;
+  mapIntoArray(children, result, '', '', function (child) {
+    return func.call(context, child, count++);
+  });
+  return result;
+}
+function lazyInitializer(payload) {
+  if (-1 === payload._status) {
+    var ctor = payload._result;
+    ctor = ctor();
+    ctor.then(
+      function (moduleObject) {
+        if (0 === payload._status || -1 === payload._status)
+          (payload._status = 1), (payload._result = moduleObject);
+      },
+      function (error) {
+        if (0 === payload._status || -1 === payload._status)
+          (payload._status = 2), (payload._result = error);
+      },
+    );
+    -1 === payload._status && ((payload._status = 0), (payload._result = ctor));
+  }
+  if (1 === payload._status) return payload._result.default;
+  throw payload._result;
+}
+var reportGlobalError =
+  'function' === typeof reportError
+    ? reportError
+    : function (error) {
+        if ('object' === typeof window && 'function' === typeof window.ErrorEvent) {
+          var event = new window.ErrorEvent('error', {
+            bubbles: !0,
+            cancelable: !0,
+            message:
+              'object' === typeof error && null !== error && 'string' === typeof error.message
+                ? String(error.message)
+                : String(error),
+            error: error,
+          });
+          if (!window.dispatchEvent(event)) return;
+        } else if ('object' === typeof process && 'function' === typeof process.emit) {
+          process.emit('uncaughtException', error);
+          return;
+        }
+        console.error(error);
+      };
+function noop() {}
+exports.Children = {
+  map: mapChildren,
+  forEach: function (children, forEachFunc, forEachContext) {
+    mapChildren(
+      children,
+      function () {
+        forEachFunc.apply(this, arguments);
+      },
+      forEachContext,
+    );
+  },
+  count: function (children) {
+    var n = 0;
+    mapChildren(children, function () {
+      n++;
+    });
+    return n;
+  },
+  toArray: function (children) {
+    return (
+      mapChildren(children, function (child) {
+        return child;
+      }) || []
+    );
+  },
+  only: function (children) {
+    if (!isValidElement(children))
+      throw Error('React.Children.only expected to receive a single React element child.');
+    return children;
+  },
+};
+exports.Component = Component;
+exports.Fragment = REACT_FRAGMENT_TYPE;
+exports.Profiler = REACT_PROFILER_TYPE;
+exports.PureComponent = PureComponent;
+exports.StrictMode = REACT_STRICT_MODE_TYPE;
+exports.Suspense = REACT_SUSPENSE_TYPE;
+exports.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = ReactSharedInternals;
+exports.act = function () {
+  throw Error('act(...) is not supported in production builds of React.');
+};
+exports.cache = function (fn) {
+  return function () {
+    return fn.apply(null, arguments);
+  };
+};
+exports.cloneElement = function (element, config, children) {
+  if (null === element || void 0 === element)
+    throw Error('The argument must be a React element, but you passed ' + element + '.');
+  var props = assign({}, element.props),
+    key = element.key,
+    owner = void 0;
+  if (null != config)
+    for (propName in (void 0 !== config.ref && (owner = void 0),
+    void 0 !== config.key && (key = '' + config.key),
+    config))
+      !hasOwnProperty.call(config, propName) ||
+        'key' === propName ||
+        '__self' === propName ||
+        '__source' === propName ||
+        ('ref' === propName && void 0 === config.ref) ||
+        (props[propName] = config[propName]);
+  var propName = arguments.length - 2;
+  if (1 === propName) props.children = children;
+  else if (1 < propName) {
+    for (var childArray = Array(propName), i = 0; i < propName; i++)
+      childArray[i] = arguments[i + 2];
+    props.children = childArray;
+  }
+  return ReactElement(element.type, key, void 0, void 0, owner, props);
+};
+exports.createContext = function (defaultValue) {
+  defaultValue = {
+    $$typeof: REACT_CONTEXT_TYPE,
+    _currentValue: defaultValue,
+    _currentValue2: defaultValue,
+    _threadCount: 0,
+    Provider: null,
+    Consumer: null,
+  };
+  defaultValue.Provider = defaultValue;
+  defaultValue.Consumer = {
+    $$typeof: REACT_CONSUMER_TYPE,
+    _context: defaultValue,
+  };
+  return defaultValue;
+};
+exports.createElement = function (type, config, children) {
+  var propName,
+    props = {},
+    key = null;
+  if (null != config)
+    for (propName in (void 0 !== config.key && (key = '' + config.key), config))
+      hasOwnProperty.call(config, propName) &&
+        'key' !== propName &&
+        '__self' !== propName &&
+        '__source' !== propName &&
+        (props[propName] = config[propName]);
+  var childrenLength = arguments.length - 2;
+  if (1 === childrenLength) props.children = children;
+  else if (1 < childrenLength) {
+    for (var childArray = Array(childrenLength), i = 0; i < childrenLength; i++)
+      childArray[i] = arguments[i + 2];
+    props.children = childArray;
+  }
+  if (type && type.defaultProps)
+    for (propName in ((childrenLength = type.defaultProps), childrenLength))
+      void 0 === props[propName] && (props[propName] = childrenLength[propName]);
+  return ReactElement(type, key, void 0, void 0, null, props);
+};
+exports.createRef = function () {
+  return {
+    current: null,
+  };
+};
+exports.forwardRef = function (render) {
+  return {
+    $$typeof: REACT_FORWARD_REF_TYPE,
+    render: render,
+  };
+};
+exports.isValidElement = isValidElement;
+exports.lazy = function (ctor) {
+  return {
+    $$typeof: REACT_LAZY_TYPE,
+    _payload: {
+      _status: -1,
+      _result: ctor,
+    },
+    _init: lazyInitializer,
+  };
+};
+exports.memo = function (type, compare) {
+  return {
+    $$typeof: REACT_MEMO_TYPE,
+    type: type,
+    compare: void 0 === compare ? null : compare,
+  };
+};
+exports.startTransition = function (scope) {
+  var prevTransition = ReactSharedInternals.T,
+    currentTransition = {};
+  ReactSharedInternals.T = currentTransition;
+  try {
+    var returnValue = scope(),
+      onStartTransitionFinish = ReactSharedInternals.S;
+    null !== onStartTransitionFinish && onStartTransitionFinish(currentTransition, returnValue);
+    'object' === typeof returnValue &&
+      null !== returnValue &&
+      'function' === typeof returnValue.then &&
+      returnValue.then(noop, reportGlobalError);
+  } catch (error) {
+    reportGlobalError(error);
+  } finally {
+    ReactSharedInternals.T = prevTransition;
+  }
+};
+exports.unstable_useCacheRefresh = function () {
+  return ReactSharedInternals.H.useCacheRefresh();
+};
+exports.use = function (usable) {
+  return ReactSharedInternals.H.use(usable);
+};
+exports.useActionState = function (action, initialState, permalink) {
+  return ReactSharedInternals.H.useActionState(action, initialState, permalink);
+};
+exports.useCallback = function (callback, deps) {
+  return ReactSharedInternals.H.useCallback(callback, deps);
+};
+exports.useContext = function (Context) {
+  return ReactSharedInternals.H.useContext(Context);
+};
+exports.useDebugValue = function () {};
+exports.useDeferredValue = function (value, initialValue) {
+  return ReactSharedInternals.H.useDeferredValue(value, initialValue);
+};
+exports.useEffect = function (create, deps) {
+  return ReactSharedInternals.H.useEffect(create, deps);
+};
+exports.useId = function () {
+  return ReactSharedInternals.H.useId();
+};
+exports.useImperativeHandle = function (ref, create, deps) {
+  return ReactSharedInternals.H.useImperativeHandle(ref, create, deps);
+};
+exports.useInsertionEffect = function (create, deps) {
+  return ReactSharedInternals.H.useInsertionEffect(create, deps);
+};
+exports.useLayoutEffect = function (create, deps) {
+  return ReactSharedInternals.H.useLayoutEffect(create, deps);
+};
+exports.useMemo = function (create, deps) {
+  return ReactSharedInternals.H.useMemo(create, deps);
+};
+exports.useOptimistic = function (passthrough, reducer) {
+  return ReactSharedInternals.H.useOptimistic(passthrough, reducer);
+};
+exports.useReducer = function (reducer, initialArg, init) {
+  return ReactSharedInternals.H.useReducer(reducer, initialArg, init);
+};
+exports.useRef = function (initialValue) {
+  return ReactSharedInternals.H.useRef(initialValue);
+};
+exports.useState = function (initialState) {
+  return ReactSharedInternals.H.useState(initialState);
+};
+exports.useSyncExternalStore = function (subscribe, getSnapshot, getServerSnapshot) {
+  return ReactSharedInternals.H.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+};
+exports.useTransition = function () {
+  return ReactSharedInternals.H.useTransition();
+};
+exports.version = '19.0.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,78 +241,17 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -847,9 +786,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -873,9 +812,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -904,105 +843,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "dependencies": {
+        "@babel/types": "^7.27.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1862,9 +1721,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -1880,14 +1739,14 @@
       "dev": true
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1947,13 +1806,12 @@
       "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2412,19 +2270,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@jest/core/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/@jest/core/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2773,19 +2618,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/@jest/transform/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/@jest/transform/node_modules/slash": {
       "version": "3.0.0",
@@ -3623,9 +3455,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3735,15 +3567,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -5083,19 +4906,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-config/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/jest-config/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5324,19 +5134,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/jest-haste-map/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/jest-haste-map/node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5466,19 +5263,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/jest-message-util/node_modules/slash": {
@@ -6135,9 +5919,9 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "node_modules/js-yaml": {
@@ -6297,6 +6081,19 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -7064,14 +6861,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7458,65 +7247,14 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/compat-data": {
@@ -7887,9 +7625,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="
     },
     "@babel/helper-transform-fixture-test-runner": {
       "version": "7.22.19",
@@ -7907,9 +7645,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="
     },
     "@babel/helper-validator-option": {
       "version": "7.22.15",
@@ -7929,89 +7667,22 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "requires": {
+        "@babel/types": "^7.27.0"
+      }
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.20.7",
@@ -8571,9 +8242,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
@@ -8588,14 +8259,14 @@
       }
     },
     "@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/traverse": {
@@ -8640,13 +8311,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       }
     },
     "@bcoe/v8-coverage": {
@@ -8973,16 +8643,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "micromatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -9248,16 +8908,6 @@
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
           "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
           "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
         },
         "slash": {
           "version": "3.0.0",
@@ -9907,9 +9557,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -9988,12 +9638,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "eslint": {
@@ -10959,16 +10603,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "micromatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11137,16 +10771,6 @@
           "dev": true,
           "optional": true
         },
-        "micromatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -11241,16 +10865,6 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
-          }
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
           }
         },
         "slash": {
@@ -11744,9 +11358,9 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -11882,6 +11496,16 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      }
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -12420,11 +12044,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -459,17 +459,8 @@ function extendReactElementWithRef(path) {
     return;
   }
 
-  // Make sure that we have the $$typeof as a sibling, and it has a variable
-  // reference as its contents.
-  const typeofIdentifierNode = path.parentPath.node.properties.find(property => {
-    return t.isObjectProperty(property) && property.key.name === '$$typeof';
-  });
-  if (!typeofIdentifierNode || !t.isIdentifier(typeofIdentifierNode.value)) {
-    return;
-  }
-
   // Ensure that the value of $$typeof is a Symbol for 'react.element' or 'react.transitional.element'
-  const typeofDeclPath = path.scope.getBinding(typeofIdentifierNode.value.name).path;
+  const typeofDeclPath = path.scope.getBinding(path.node.value.name).path;
   if (
     !t.isVariableDeclarator(typeofDeclPath.node) ||
     !t.isCallExpression(typeofDeclPath.node.init) ||

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import * as babylon from '@babel/parser';
 import * as t from '@babel/types';
 
+// The return value of this function will be evaluated as JavaScript code.
 const setRefBackwardCompat = (refIdentifier, propsIdentifier) => {
   if (refIdentifier) {
     // React versions < 19
@@ -447,11 +448,15 @@ function extendReactElementWithRef(path) {
 
    * We identify this by looking for the $$typeof property set on an object and
    * where $$typeof is set to Symbol.for('react.element') or Symbol.for('react.transitional.element')
-   *
-   *   var foo = Symbol.for('react.element');
-   *   [...]
-   *   var bar;
-   *   { $$typeof: foo, ..., ref: bar, ... }
+   * 
+   * This is the structure of the element object in React:
+   *   const element = {
+   *     $$typeof: REACT_ELEMENT_TYPE,
+   *     type: type,
+   *     key: key,
+   *     ref: ref, // this does not exist in React >=19
+   *     props: props, // props.ref has the ref in React >=19
+   *     _owner: owner,
    */
 
   // Are we actually looking at the ref: in there, and does it refer to a single variable?


### PR DESCRIPTION
In React 19, `ref` values are now coming from `props`. We need to update our babel rewrites to support this. 

https://app.staging.fullstory.com/ui/3RWN/session/5669605071159296:5967848006112717165 -RN 78 iOS

https://app.staging.fullstory.com/ui/3RWN/session/6513970844827648:6446848419003676642 - RN legacy

For those not familiar, a good way to grok how we're intending to extend React code is in `__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js`