### PR TITLE
React Native 81 iOS support & React 19 bugfixes

### DIFF
--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
@@ -711,27 +711,20 @@ if (process.env.NODE_ENV !== 'production') {
       ];
       const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
       if (isTurboModuleEnabled && Platform.OS === 'ios') {
-        if (
-          type.$$typeof &&
-          (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-            type.$$typeof.toString() === 'Symbol(react.element)' ||
-            type.$$typeof.toString() === 'Symbol(react.transitional.element)')
-        ) {
-          if (props) {
-            const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-              if (!!props[fsAttribute]) {
-                if (fsAttribute === 'fsAttribute') {
-                  return typeof props[fsAttribute] === 'object';
-                } else {
-                  return typeof props[fsAttribute] === 'string';
-                }
+        if (props) {
+          const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+            if (!!props[fsAttribute]) {
+              if (fsAttribute === 'fsAttribute') {
+                return typeof props[fsAttribute] === 'object';
+              } else {
+                return typeof props[fsAttribute] === 'string';
               }
-              return false;
-            });
-            if (propContainsFSAttribute) {
-              const fs = require('@fullstory/react-native');
-              ref = fs.applyFSPropertiesWithRef(ref);
             }
+            return false;
+          });
+          if (propContainsFSAttribute) {
+            const fs = require('@fullstory/react-native');
+            ref = fs.applyFSPropertiesWithRef(ref);
           }
         }
       }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/code.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/code.js
@@ -7,9 +7,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const { applyFSPropertiesWithRef } = require('@fullstory/react-native/src');
 
-('use strict');
+'use strict';
 'production' !== process.env.NODE_ENV &&
   (function () {
     function defineDeprecationWarning(methodName, info) {
@@ -420,7 +419,6 @@ const { applyFSPropertiesWithRef } = require('@fullstory/react-native/src');
       return void 0 !== componentName ? componentName : null;
     }
     function ReactElement(type, key, self, source, owner, props) {
-      props = { ...props, ref: applyFSPropertiesWithRef(props.ref) };
       self = props.ref;
       type = {
         $$typeof: REACT_ELEMENT_TYPE,

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
@@ -7,8 +7,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const { applyFSPropertiesWithRef } = require('@fullstory/react-native/src');
-('use strict');
+
+'use strict';
+
 'production' !== process.env.NODE_ENV &&
   (function () {
     function defineDeprecationWarning(methodName, info) {
@@ -437,11 +438,6 @@ const { applyFSPropertiesWithRef } = require('@fullstory/react-native/src');
       return void 0 !== componentName ? componentName : null;
     }
     function ReactElement(type, key, self, source, owner, props) {
-      props = {
-        ...props,
-        ref: applyFSPropertiesWithRef(props.ref),
-      };
-      self = props.ref;
       const { Platform } = require('react-native');
       const SUPPORTED_FS_ATTRIBUTES = [
         'fsClass',
@@ -453,33 +449,27 @@ const { applyFSPropertiesWithRef } = require('@fullstory/react-native/src');
       ];
       const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
       if (isTurboModuleEnabled && Platform.OS === 'ios') {
-        if (
-          type.$$typeof &&
-          (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-            type.$$typeof.toString() === 'Symbol(react.element)' ||
-            type.$$typeof.toString() === 'Symbol(react.transitional.element)')
-        ) {
-          if (props) {
-            const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-              if (!!props[fsAttribute]) {
-                if (fsAttribute === 'fsAttribute') {
-                  return typeof props[fsAttribute] === 'object';
-                } else {
-                  return typeof props[fsAttribute] === 'string';
-                }
+        if (props) {
+          const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+            if (!!props[fsAttribute]) {
+              if (fsAttribute === 'fsAttribute') {
+                return typeof props[fsAttribute] === 'object';
+              } else {
+                return typeof props[fsAttribute] === 'string';
               }
-              return false;
-            });
-            if (propContainsFSAttribute) {
-              const fs = require('@fullstory/react-native');
-              props = {
-                ...props,
-                ref: fs.applyFSPropertiesWithRef(props['ref']),
-              };
             }
+            return false;
+          });
+          if (propContainsFSAttribute) {
+            const fs = require('@fullstory/react-native');
+            props = {
+              ...props,
+              ref: fs.applyFSPropertiesWithRef(props['ref']),
+            };
           }
         }
       }
+      self = props.ref;
       type = {
         $$typeof: REACT_ELEMENT_TYPE,
         type: type,

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
@@ -817,27 +817,20 @@ if (process.env.NODE_ENV !== 'production') {
       ];
       const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
       if (isTurboModuleEnabled && Platform.OS === 'ios') {
-        if (
-          type.$$typeof &&
-          (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-            type.$$typeof.toString() === 'Symbol(react.element)' ||
-            type.$$typeof.toString() === 'Symbol(react.transitional.element)')
-        ) {
-          if (props) {
-            const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-              if (!!props[fsAttribute]) {
-                if (fsAttribute === 'fsAttribute') {
-                  return typeof props[fsAttribute] === 'object';
-                } else {
-                  return typeof props[fsAttribute] === 'string';
-                }
+        if (props) {
+          const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+            if (!!props[fsAttribute]) {
+              if (fsAttribute === 'fsAttribute') {
+                return typeof props[fsAttribute] === 'object';
+              } else {
+                return typeof props[fsAttribute] === 'string';
               }
-              return false;
-            });
-            if (propContainsFSAttribute) {
-              const fs = require('@fullstory/react-native');
-              ref = fs.applyFSPropertiesWithRef(ref);
             }
+            return false;
+          });
+          if (propContainsFSAttribute) {
+            const fs = require('@fullstory/react-native');
+            ref = fs.applyFSPropertiesWithRef(ref);
           }
         }
       }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
@@ -372,7 +372,6 @@
       return void 0 !== componentName ? componentName : null;
     }
     function ReactElement(type, key, self, source, owner, props) {
-      self = props.ref;
       const { Platform } = require('react-native');
       const SUPPORTED_FS_ATTRIBUTES = [
         'fsClass',
@@ -384,33 +383,27 @@
       ];
       const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
       if (isTurboModuleEnabled && Platform.OS === 'ios') {
-        if (
-          type.$$typeof &&
-          (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-            type.$$typeof.toString() === 'Symbol(react.element)' ||
-            type.$$typeof.toString() === 'Symbol(react.transitional.element)')
-        ) {
-          if (props) {
-            const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-              if (!!props[fsAttribute]) {
-                if (fsAttribute === 'fsAttribute') {
-                  return typeof props[fsAttribute] === 'object';
-                } else {
-                  return typeof props[fsAttribute] === 'string';
-                }
+        if (props) {
+          const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+            if (!!props[fsAttribute]) {
+              if (fsAttribute === 'fsAttribute') {
+                return typeof props[fsAttribute] === 'object';
+              } else {
+                return typeof props[fsAttribute] === 'string';
               }
-              return false;
-            });
-            if (propContainsFSAttribute) {
-              const fs = require('@fullstory/react-native');
-              props = {
-                ...props,
-                ref: fs.applyFSPropertiesWithRef(props['ref']),
-              };
             }
+            return false;
+          });
+          if (propContainsFSAttribute) {
+            const fs = require('@fullstory/react-native');
+            props = {
+              ...props,
+              ref: fs.applyFSPropertiesWithRef(props['ref']),
+            };
           }
         }
       }
+      self = props.ref;
       type = {
         $$typeof: REACT_ELEMENT_TYPE,
         type: type,

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
@@ -41,27 +41,20 @@ function q(c, a, g) {
   ];
   const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
-    if (
-      c.$$typeof &&
-      (c.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-        c.$$typeof.toString() === 'Symbol(react.element)' ||
-        c.$$typeof.toString() === 'Symbol(react.transitional.element)')
-    ) {
-      if (d) {
-        const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-          if (!!props[fsAttribute]) {
-            if (fsAttribute === 'fsAttribute') {
-              return typeof props[fsAttribute] === 'object';
-            } else {
-              return typeof props[fsAttribute] === 'string';
-            }
+    if (d) {
+      const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+        if (!!props[fsAttribute]) {
+          if (fsAttribute === 'fsAttribute') {
+            return typeof props[fsAttribute] === 'object';
+          } else {
+            return typeof props[fsAttribute] === 'string';
           }
-          return false;
-        });
-        if (propContainsFSAttribute) {
-          const fs = require('@fullstory/react-native');
-          h = fs.applyFSPropertiesWithRef(h);
         }
+        return false;
+      });
+      if (propContainsFSAttribute) {
+        const fs = require('@fullstory/react-native');
+        h = fs.applyFSPropertiesWithRef(h);
       }
     }
   }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
@@ -43,11 +43,11 @@ function q(c, a, g) {
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
     if (d) {
       const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-        if (!!props[fsAttribute]) {
+        if (!!d[fsAttribute]) {
           if (fsAttribute === 'fsAttribute') {
-            return typeof props[fsAttribute] === 'object';
+            return typeof d[fsAttribute] === 'object';
           } else {
-            return typeof props[fsAttribute] === 'string';
+            return typeof d[fsAttribute] === 'string';
           }
         }
         return false;

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
@@ -13,6 +13,13 @@
 var REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
   REACT_FRAGMENT_TYPE = Symbol.for('react.fragment');
 function jsxProd(type, config, maybeKey) {
+  var key = null;
+  void 0 !== maybeKey && (key = '' + maybeKey);
+  void 0 !== config.key && (key = '' + config.key);
+  if ('key' in config) {
+    maybeKey = {};
+    for (var propName in config) 'key' !== propName && (maybeKey[propName] = config[propName]);
+  } else maybeKey = config;
   const { Platform } = require('react-native');
   const SUPPORTED_FS_ATTRIBUTES = [
     'fsClass',
@@ -26,11 +33,11 @@ function jsxProd(type, config, maybeKey) {
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
     if (maybeKey) {
       const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-        if (!!props[fsAttribute]) {
+        if (!!maybeKey[fsAttribute]) {
           if (fsAttribute === 'fsAttribute') {
-            return typeof props[fsAttribute] === 'object';
+            return typeof maybeKey[fsAttribute] === 'object';
           } else {
-            return typeof props[fsAttribute] === 'string';
+            return typeof maybeKey[fsAttribute] === 'string';
           }
         }
         return false;
@@ -44,13 +51,6 @@ function jsxProd(type, config, maybeKey) {
       }
     }
   }
-  var key = null;
-  void 0 !== maybeKey && (key = '' + maybeKey);
-  void 0 !== config.key && (key = '' + config.key);
-  if ('key' in config) {
-    maybeKey = {};
-    for (var propName in config) 'key' !== propName && (maybeKey[propName] = config[propName]);
-  } else maybeKey = config;
   config = maybeKey.ref;
   return {
     $$typeof: REACT_ELEMENT_TYPE,

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
@@ -13,14 +13,6 @@
 var REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element'),
   REACT_FRAGMENT_TYPE = Symbol.for('react.fragment');
 function jsxProd(type, config, maybeKey) {
-  var key = null;
-  void 0 !== maybeKey && (key = '' + maybeKey);
-  void 0 !== config.key && (key = '' + config.key);
-  if ('key' in config) {
-    maybeKey = {};
-    for (var propName in config) 'key' !== propName && (maybeKey[propName] = config[propName]);
-  } else maybeKey = config;
-  config = maybeKey.ref;
   const { Platform } = require('react-native');
   const SUPPORTED_FS_ATTRIBUTES = [
     'fsClass',
@@ -32,33 +24,34 @@ function jsxProd(type, config, maybeKey) {
   ];
   const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
-    if (
-      type.$$typeof &&
-      (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-        type.$$typeof.toString() === 'Symbol(react.element)' ||
-        type.$$typeof.toString() === 'Symbol(react.transitional.element)')
-    ) {
-      if (maybeKey) {
-        const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-          if (!!props[fsAttribute]) {
-            if (fsAttribute === 'fsAttribute') {
-              return typeof props[fsAttribute] === 'object';
-            } else {
-              return typeof props[fsAttribute] === 'string';
-            }
+    if (maybeKey) {
+      const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+        if (!!props[fsAttribute]) {
+          if (fsAttribute === 'fsAttribute') {
+            return typeof props[fsAttribute] === 'object';
+          } else {
+            return typeof props[fsAttribute] === 'string';
           }
-          return false;
-        });
-        if (propContainsFSAttribute) {
-          const fs = require('@fullstory/react-native');
-          maybeKey = {
-            ...maybeKey,
-            ref: fs.applyFSPropertiesWithRef(maybeKey['ref']),
-          };
         }
+        return false;
+      });
+      if (propContainsFSAttribute) {
+        const fs = require('@fullstory/react-native');
+        maybeKey = {
+          ...maybeKey,
+          ref: fs.applyFSPropertiesWithRef(maybeKey['ref']),
+        };
       }
     }
   }
+  var key = null;
+  void 0 !== maybeKey && (key = '' + maybeKey);
+  void 0 !== config.key && (key = '' + config.key);
+  if ('key' in config) {
+    maybeKey = {};
+    for (var propName in config) 'key' !== propName && (maybeKey[propName] = config[propName]);
+  } else maybeKey = config;
+  config = maybeKey.ref;
   return {
     $$typeof: REACT_ELEMENT_TYPE,
     type: type,

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
@@ -102,27 +102,20 @@ function M(a, b, e) {
   ];
   const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
-    if (
-      a.$$typeof &&
-      (a.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-        a.$$typeof.toString() === 'Symbol(react.element)' ||
-        a.$$typeof.toString() === 'Symbol(react.transitional.element)')
-    ) {
-      if (c) {
-        const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-          if (!!props[fsAttribute]) {
-            if (fsAttribute === 'fsAttribute') {
-              return typeof props[fsAttribute] === 'object';
-            } else {
-              return typeof props[fsAttribute] === 'string';
-            }
+    if (c) {
+      const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+        if (!!props[fsAttribute]) {
+          if (fsAttribute === 'fsAttribute') {
+            return typeof props[fsAttribute] === 'object';
+          } else {
+            return typeof props[fsAttribute] === 'string';
           }
-          return false;
-        });
-        if (propContainsFSAttribute) {
-          const fs = require('@fullstory/react-native');
-          h = fs.applyFSPropertiesWithRef(h);
         }
+        return false;
+      });
+      if (propContainsFSAttribute) {
+        const fs = require('@fullstory/react-native');
+        h = fs.applyFSPropertiesWithRef(h);
       }
     }
   }
@@ -336,27 +329,20 @@ exports.cloneElement = function (a, b, e) {
   ];
   const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
-    if (
-      a.$$typeof &&
-      (a.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-        a.$$typeof.toString() === 'Symbol(react.element)' ||
-        a.$$typeof.toString() === 'Symbol(react.transitional.element)')
-    ) {
-      if (d) {
-        const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-          if (!!props[fsAttribute]) {
-            if (fsAttribute === 'fsAttribute') {
-              return typeof props[fsAttribute] === 'object';
-            } else {
-              return typeof props[fsAttribute] === 'string';
-            }
+    if (d) {
+      const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+        if (!!props[fsAttribute]) {
+          if (fsAttribute === 'fsAttribute') {
+            return typeof props[fsAttribute] === 'object';
+          } else {
+            return typeof props[fsAttribute] === 'string';
           }
-          return false;
-        });
-        if (propContainsFSAttribute) {
-          const fs = require('@fullstory/react-native');
-          k = fs.applyFSPropertiesWithRef(k);
         }
+        return false;
+      });
+      if (propContainsFSAttribute) {
+        const fs = require('@fullstory/react-native');
+        k = fs.applyFSPropertiesWithRef(k);
       }
     }
   }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
@@ -104,11 +104,11 @@ function M(a, b, e) {
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
     if (c) {
       const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-        if (!!props[fsAttribute]) {
+        if (!!c[fsAttribute]) {
           if (fsAttribute === 'fsAttribute') {
-            return typeof props[fsAttribute] === 'object';
+            return typeof c[fsAttribute] === 'object';
           } else {
-            return typeof props[fsAttribute] === 'string';
+            return typeof c[fsAttribute] === 'string';
           }
         }
         return false;
@@ -331,11 +331,11 @@ exports.cloneElement = function (a, b, e) {
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
     if (d) {
       const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-        if (!!props[fsAttribute]) {
+        if (!!d[fsAttribute]) {
           if (fsAttribute === 'fsAttribute') {
-            return typeof props[fsAttribute] === 'object';
+            return typeof d[fsAttribute] === 'object';
           } else {
-            return typeof props[fsAttribute] === 'string';
+            return typeof d[fsAttribute] === 'string';
           }
         }
         return false;

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
@@ -80,7 +80,6 @@ var isArrayImpl = Array.isArray,
   },
   hasOwnProperty = Object.prototype.hasOwnProperty;
 function ReactElement(type, key, self, source, owner, props) {
-  self = props.ref;
   const { Platform } = require('react-native');
   const SUPPORTED_FS_ATTRIBUTES = [
     'fsClass',
@@ -92,33 +91,27 @@ function ReactElement(type, key, self, source, owner, props) {
   ];
   const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
   if (isTurboModuleEnabled && Platform.OS === 'ios') {
-    if (
-      type.$$typeof &&
-      (type.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
-        type.$$typeof.toString() === 'Symbol(react.element)' ||
-        type.$$typeof.toString() === 'Symbol(react.transitional.element)')
-    ) {
-      if (props) {
-        const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
-          if (!!props[fsAttribute]) {
-            if (fsAttribute === 'fsAttribute') {
-              return typeof props[fsAttribute] === 'object';
-            } else {
-              return typeof props[fsAttribute] === 'string';
-            }
+    if (props) {
+      const propContainsFSAttribute = SUPPORTED_FS_ATTRIBUTES.some(fsAttribute => {
+        if (!!props[fsAttribute]) {
+          if (fsAttribute === 'fsAttribute') {
+            return typeof props[fsAttribute] === 'object';
+          } else {
+            return typeof props[fsAttribute] === 'string';
           }
-          return false;
-        });
-        if (propContainsFSAttribute) {
-          const fs = require('@fullstory/react-native');
-          props = {
-            ...props,
-            ref: fs.applyFSPropertiesWithRef(props['ref']),
-          };
         }
+        return false;
+      });
+      if (propContainsFSAttribute) {
+        const fs = require('@fullstory/react-native');
+        props = {
+          ...props,
+          ref: fs.applyFSPropertiesWithRef(props['ref']),
+        };
       }
     }
   }
+  self = props.ref;
   return {
     $$typeof: REACT_ELEMENT_TYPE,
     type: type,


### PR DESCRIPTION
The way that we rewrote react element creation functions needed to be enhanced to fix bugs and support RN 81. 

We currently have `code.js` and their respective `output.js` to demonstrate the results of the rewrite. Please see my comments in each file that demonstrates the changes made in this PR.

Sessions after testing:
RN 0.81.0 release mode - [session](https://app.fullstory.com/ui/H0SZW/client-session/b7714676-de46-4d00-8116-59afb9188000:4a337701-7e36-489f-9911-9554c1b1c63c)
RN 0.81.0 development mode - [session](https://app.fullstory.com/ui/H0SZW/session/6291060747173888:4466447110622618186)
RN 0.78.3 release mode - [session](https://app.fullstory.com/ui/H0SZW/session/6283220301152256:5948913958427560792)
RN 0.78.3 development mode [session](https://app.staging.fullstory.com/ui/3RWN/session/5777015472422912:6198321912937520516)
