### PR TITLE
support forwardedRef

### DIFF
--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
@@ -483,7 +483,7 @@
               const fs = require('@fullstory/react-native');
               props = {
                 ...props,
-                ref: fs.applyFSPropertiesWithRef(props['ref']),
+                ref: fs.applyFSPropertiesWithRef(props['ref'] || props['forwardedRef']),
               };
             }
           }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
@@ -417,7 +417,7 @@
               const fs = require('@fullstory/react-native');
               props = {
                 ...props,
-                ref: fs.applyFSPropertiesWithRef(props['ref']),
+                ref: fs.applyFSPropertiesWithRef(props['ref'] || props['forwardedRef']),
               };
             }
           }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
@@ -65,7 +65,7 @@ function jsxProd(type, config, maybeKey) {
           const fs = require('@fullstory/react-native');
           maybeKey = {
             ...maybeKey,
-            ref: fs.applyFSPropertiesWithRef(maybeKey['ref']),
+            ref: fs.applyFSPropertiesWithRef(maybeKey['ref'] || maybeKey['forwardedRef']),
           };
         }
       }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
@@ -125,7 +125,7 @@ function ReactElement(type, key, self, source, owner, props) {
           const fs = require('@fullstory/react-native');
           props = {
             ...props,
-            ref: fs.applyFSPropertiesWithRef(props['ref']),
+            ref: fs.applyFSPropertiesWithRef(props['ref'] || props['forwardedRef']),
           };
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const setRefBackwardCompat = (refIdentifier, propsIdentifier) => {
     return `${refIdentifier} = fs.applyFSPropertiesWithRef(${refIdentifier});`;
   }
   // React versions >= 19
-  return `${propsIdentifier} = { ...${propsIdentifier}, ref: fs.applyFSPropertiesWithRef(${propsIdentifier}['ref']) }`;
+  return `${propsIdentifier} = { ...${propsIdentifier}, ref: fs.applyFSPropertiesWithRef(${propsIdentifier}['ref'] || ${propsIdentifier}['forwardedRef']) }`;
 };
 // We only add our ref to all Symbol(react.forward_ref) and Symbol(react.element) types, since they support refs
 const _createFabricRefCode = (refIdentifier, typeIdentifier, propsIdentifier) => `
@@ -49,8 +49,8 @@ const _createFabricRefCode = (refIdentifier, typeIdentifier, propsIdentifier) =>
       });
 
       if (propContainsFSAttribute) {
-        const fs  = require('@fullstory/react-native');
-        ${setRefBackwardCompat(refIdentifier, propsIdentifier)}
+          const fs  = require('@fullstory/react-native');
+          ${setRefBackwardCompat(refIdentifier, propsIdentifier)}
         }
       }
     } 


### PR DESCRIPTION
### Issue
https://fullstory.atlassian.net/browse/VAL-9602
We have a reported issue where this [error](https://github.com/software-mansion/react-native-gesture-handler/blob/f4977552b43c67348bc1974415d884e1da95c2a3/packages/react-native-gesture-handler/src/handlers/createHandler.tsx#L246) is thrown in `react-native-gesture-handler`. 

This is caused by the customer using `TextInput` imported from `react-native-gesture-handler`. `react-native-gesture-handler` wraps the React Native `TextInput` in their own [wrapper](https://github.com/software-mansion/react-native-gesture-handler/blob/f4977552b43c67348bc1974415d884e1da95c2a3/packages/react-native-gesture-handler/src/handlers/createNativeWrapper.tsx#L23), which expects the [ref handler](https://github.com/software-mansion/react-native-gesture-handler/blob/f4977552b43c67348bc1974415d884e1da95c2a3/packages/react-native-gesture-handler/src/handlers/createHandler.tsx#L309) to be called.

You'll see in `react-native` that [TextInput](https://github.com/facebook/react-native/blob/f33a1cd2605309b86201ac9669b95ca87530caec/packages/react-native/Libraries/Components/TextInput/TextInput.js#L947) sets their `ref` prop on `forwardedRef`, rather than `ref`, which causes our babel rewrite to miss passing `forwardedRef` into our wrapper `applyFSPropertiesWithRef`, which causes the ref handler from `react-native-gesture-handler` to not get called, which results in the error being thrown. 

### Fix
If `props.ref` doesn't exist, we'll attempt to pass `props['forwardedRef']`. It's safe to pass `null || undefined` into `applyFSPropertiesWithRef`