### PR TITLE
Bugfix: do not inject ref if only `forwardRef` exists

### DIFF
--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
@@ -483,7 +483,11 @@
               const fs = require('@fullstory/react-native');
               props = {
                 ...props,
-                ref: fs.applyFSPropertiesWithRef(props['ref'] || props['forwardedRef']),
+                ...(!props['ref'] && props['forwardedRef']
+                  ? {}
+                  : {
+                      ref: fs.applyFSPropertiesWithRef(props['ref']),
+                    }),
               };
             }
           }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
@@ -417,7 +417,11 @@
               const fs = require('@fullstory/react-native');
               props = {
                 ...props,
-                ref: fs.applyFSPropertiesWithRef(props['ref'] || props['forwardedRef']),
+                ...(!props['ref'] && props['forwardedRef']
+                  ? {}
+                  : {
+                      ref: fs.applyFSPropertiesWithRef(props['ref']),
+                    }),
               };
             }
           }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
@@ -65,7 +65,11 @@ function jsxProd(type, config, maybeKey) {
           const fs = require('@fullstory/react-native');
           maybeKey = {
             ...maybeKey,
-            ref: fs.applyFSPropertiesWithRef(maybeKey['ref'] || maybeKey['forwardedRef']),
+            ...(!maybeKey['ref'] && maybeKey['forwardedRef']
+              ? {}
+              : {
+                  ref: fs.applyFSPropertiesWithRef(maybeKey['ref']),
+                }),
           };
         }
       }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
@@ -125,7 +125,11 @@ function ReactElement(type, key, self, source, owner, props) {
           const fs = require('@fullstory/react-native');
           props = {
             ...props,
-            ref: fs.applyFSPropertiesWithRef(props['ref'] || props['forwardedRef']),
+            ...(!props['ref'] && props['forwardedRef']
+              ? {}
+              : {
+                  ref: fs.applyFSPropertiesWithRef(props['ref']),
+                }),
           };
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const setRefBackwardCompat = (refIdentifier, propsIdentifier) => {
     return `${refIdentifier} = fs.applyFSPropertiesWithRef(${refIdentifier});`;
   }
   // React versions >= 19
-  return `${propsIdentifier} = { ...${propsIdentifier}, ref: fs.applyFSPropertiesWithRef(${propsIdentifier}['ref'] || ${propsIdentifier}['forwardedRef']) }`;
+  return `${propsIdentifier} = { ...${propsIdentifier}, ...(!${propsIdentifier}['ref'] && ${propsIdentifier}['forwardedRef'] ? {} : { ref: fs.applyFSPropertiesWithRef(${propsIdentifier}['ref']) }) }`;
 };
 // We only add our ref to all Symbol(react.forward_ref) and Symbol(react.element) types, since they support refs
 const _createFabricRefCode = (refIdentifier, typeIdentifier, propsIdentifier) => `


### PR DESCRIPTION
### Problem
We have several bug reports regarding `ref` issues due to #52 . [VAL-9619](https://fullstory.atlassian.net/browse/VAL-9619) [VAL-9669](https://fullstory.atlassian.net/browse/VAL-9669)

The fix in #52 had side effects due to the [unexpected](https://github.com/facebook/react-native/blob/f33a1cd2605309b86201ac9669b95ca87530caec/packages/react-native/Libraries/Components/TextInput/TextInput.js#L429C7-L450C9) way `TextInput` in react native handled refs. It's difficult to understand the levels of misdirection within `TextInput` so the best way to ensure we're handling these edge cases is through comprehensive testing. 

### The Fix
For some reason, when `props['ref']` is undefined but `props['forwardedRef']` exists, us adding a function ref causes the end result's `ref` to lose its associated reference methods. This occurs even when ref is set to `undefined`:
```
props = {
        ...props,
        ref: props['ref'] // ref is undefined
}
```

The fix is a more conservative approach, where if `props['ref']` is undefined but `props['forwardedRef']` exists, we will avoid rewriting the props.

Through manual testing I have found that we do not lose the ability to read any fullstory attributes within our demo.
https://app.staging.fullstory.com/ui/3RWN/session/5517163529535488:7769933313926955914

Essentially, rolls back the amount of props we rewrite, without adding new functionality, while retaining the fix for #52.

### Testing
* I've [added](https://github.com/cowpaths/mn/pull/94349) all the failing test scenarios in our demo and tested this new implementation with both react version `19.0.0` and `19.1.0`. 
* I've also validated our solution on a customer call with `VAL-9619` and it has been confirmed to fix their Text Input issues
* With VAL-9669, the customer app is open source. I've validated the fix with their app as well.