### PR TITLE
fix: prevent phantom ref injection on React 19+ when no ref exists

### DIFF
--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
@@ -468,14 +468,14 @@
             }
             props = {
               ...props,
-              ...(!props['ref'] && props['forwardedRef']
-                ? {}
-                : {
+              ...(props['ref']
+                ? {
                     ref: global.__FULLSTORY_BABEL_PLUGIN_module.applyFSPropertiesWithRef(
                       props['ref'],
                       hasFSDynamicAttribute,
                     ),
-                  }),
+                  }
+                : {}),
             };
           }
         }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
@@ -402,14 +402,14 @@
             }
             props = {
               ...props,
-              ...(!props['ref'] && props['forwardedRef']
-                ? {}
-                : {
+              ...(props['ref']
+                ? {
                     ref: global.__FULLSTORY_BABEL_PLUGIN_module.applyFSPropertiesWithRef(
                       props['ref'],
                       hasFSDynamicAttribute,
                     ),
-                  }),
+                  }
+                : {}),
             };
           }
         }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
@@ -54,14 +54,14 @@ function jsxProd(type, config, maybeKey) {
         }
         maybeKey = {
           ...maybeKey,
-          ...(!maybeKey['ref'] && maybeKey['forwardedRef']
-            ? {}
-            : {
+          ...(maybeKey['ref']
+            ? {
                 ref: global.__FULLSTORY_BABEL_PLUGIN_module.applyFSPropertiesWithRef(
                   maybeKey['ref'],
                   hasFSDynamicAttribute,
                 ),
-              }),
+              }
+            : {}),
         };
       }
     }

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
@@ -110,14 +110,14 @@ function ReactElement(type, key, self, source, owner, props) {
         }
         props = {
           ...props,
-          ...(!props['ref'] && props['forwardedRef']
-            ? {}
-            : {
+          ...(props['ref']
+            ? {
                 ref: global.__FULLSTORY_BABEL_PLUGIN_module.applyFSPropertiesWithRef(
                   props['ref'],
                   hasFSDynamicAttribute,
                 ),
-              }),
+              }
+            : {}),
         };
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const setRefBackwardCompat = (refIdentifier, propsIdentifier, moduleRef, hasDyna
     return `${refIdentifier} = ${moduleRef}.applyFSPropertiesWithRef(${refIdentifier}, ${hasDynamicAttribute});`;
   }
   // React versions >= 19
-  return `${propsIdentifier} = { ...${propsIdentifier}, ...(!${propsIdentifier}['ref'] && ${propsIdentifier}['forwardedRef'] ? {} : { ref: ${moduleRef}.applyFSPropertiesWithRef(${propsIdentifier}['ref'], ${hasDynamicAttribute}) }) }`;
+  return `${propsIdentifier} = { ...${propsIdentifier}, ...(${propsIdentifier}['ref'] ? { ref: ${moduleRef}.applyFSPropertiesWithRef(${propsIdentifier}['ref'], ${hasDynamicAttribute}) } : {}) }`;
 };
 
 // We only add our ref to all Symbol(react.forward_ref) and Symbol(react.element) types, since they support refs


### PR DESCRIPTION
### Summary

In React 19, `jsx()` extracts `ref` from the config into a separate element field, so `props['ref']` is always falsy at the point where `setRefBackwardCompat` runs. The current condition `!props['ref'] && props['forwardedRef']` evaluates to `true && false = false`, causing the else branch to always execute `applyFSPropertiesWithRef(undefined)`, which returns `sharedRefWrapper` a phantom ref injected into every element with FS attributes on iOS, even when no ref was originally passed.

This phantom ref propagates through components that don't destructure `ref`, leaking into `...rest` spreads and overwriting legitimate refs. This breaks focus, scroll-to, and any other ref-dependent behavior.

### Fix

Changed the condition to only wrap `props['ref']` when it actually exists:

```js
// Before (buggy)
props = { ...props, ...(!props['ref'] && props['forwardedRef'] ? {} : { ref: module.applyFSPropertiesWithRef(props['ref']) }) }

// After (fixed)
props = { ...props, ...(props['ref'] ? { ref: module.applyFSPropertiesWithRef(props['ref']) } : {}) }