### PR TITLE
Disable view optimization even if testID exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -660,9 +660,10 @@ export default function ({ types: t }) {
         }
 
         // check if view optimization is already disabled
+        // Note: testID is intentionally excluded here. testID prevents the view itself
+        // from being removed, but does NOT prevent view flattening.
         const isViewOptimizationDisabled = path.container.some(attribute => {
           return (
-            t.isJSXIdentifier(attribute.name, { name: 'testID' }) ||
             t.isJSXIdentifier(attribute.name, { name: 'id' }) ||
             t.isJSXIdentifier(attribute.name, { name: 'nativeID' })
           );


### PR DESCRIPTION
```
      <View fsClass="fs-exclude">
        <Text fsClass="fs-unmask">Excluded</Text>
      </View>
      <View fsClass="fs-exclude" testID="test-id">
        <Text fsClass="fs-unmask">Unmasked</Text>
      </View>
```
In the above example, both `<Text>` should be excluded. Even though the React Native docs[
](https://reactnative.dev/docs/view#testid) lists `testID` as a prop that will turn off view optimization, this does not actually prevent view flattening. Only `id` and `nativeID` does. We need to turn off view optimization for a `View` even if it has `testID` as a prop.

Note: this bug only occurs on iOS.

Broken session: https://app.staging.fullstory.com/ui/3RWN/session/6264295599407104:7117145039817929213
Fixed session: https://app.staging.fullstory.com/ui/3RWN/session/6264295599407104:4719180514935741262