### PR TITLE
guard against undefined type

### DIFF
--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment/output.js
@@ -706,7 +706,7 @@ if (process.env.NODE_ENV !== 'production') {
           !Platform.isTV;
       }
       if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-        const typeSymbol = type.$$typeof;
+        const typeSymbol = type != null ? type.$$typeof : undefined;
         const typeString = typeSymbol ? typeSymbol.toString() : '';
         const isValidType =
           true ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
@@ -447,7 +447,7 @@
           !Platform.isTV;
       }
       if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-        const typeSymbol = type.$$typeof;
+        const typeSymbol = type != null ? type.$$typeof : undefined;
         const typeString = typeSymbol ? typeSymbol.toString() : '';
         const isValidType =
           true ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment/output.js
@@ -810,7 +810,7 @@ if (process.env.NODE_ENV !== 'production') {
           !Platform.isTV;
       }
       if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-        const typeSymbol = type.$$typeof;
+        const typeSymbol = type != null ? type.$$typeof : undefined;
         const typeString = typeSymbol ? typeSymbol.toString() : '';
         const isValidType =
           true ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
@@ -381,7 +381,7 @@
           !Platform.isTV;
       }
       if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-        const typeSymbol = type.$$typeof;
+        const typeSymbol = type != null ? type.$$typeof : undefined;
         const typeString = typeSymbol ? typeSymbol.toString() : '';
         const isValidType =
           true ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction/output.js
@@ -38,7 +38,7 @@ function q(c, a, g) {
       !Platform.isTV;
   }
   if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-    const typeSymbol = c.$$typeof;
+    const typeSymbol = c != null ? c.$$typeof : undefined;
     const typeString = typeSymbol ? typeSymbol.toString() : '';
     const isValidType =
       true ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
@@ -29,7 +29,7 @@ function jsxProd(type, config, maybeKey) {
       !Platform.isTV;
   }
   if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-    const typeSymbol = type.$$typeof;
+    const typeSymbol = type != null ? type.$$typeof : undefined;
     const typeString = typeSymbol ? typeSymbol.toString() : '';
     const isValidType =
       true ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction/output.js
@@ -99,7 +99,7 @@ function M(a, b, e) {
       !Platform.isTV;
   }
   if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-    const typeSymbol = a.$$typeof;
+    const typeSymbol = a != null ? a.$$typeof : undefined;
     const typeString = typeSymbol ? typeSymbol.toString() : '';
     const isValidType =
       true ||
@@ -328,7 +328,7 @@ exports.cloneElement = function (a, b, e) {
       !Platform.isTV;
   }
   if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-    const typeSymbol = a.$$typeof;
+    const typeSymbol = a != null ? a.$$typeof : undefined;
     const typeString = typeSymbol ? typeSymbol.toString() : '';
     const isValidType =
       true ||

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
@@ -89,7 +89,7 @@ function ReactElement(type, key, self, source, owner, props) {
       !Platform.isTV;
   }
   if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-    const typeSymbol = type.$$typeof;
+    const typeSymbol = type != null ? type.$$typeof : undefined;
     const typeString = typeSymbol ? typeSymbol.toString() : '';
     const isValidType =
       true ||

--- a/__tests__/runtime/fabricRef.test.js
+++ b/__tests__/runtime/fabricRef.test.js
@@ -74,4 +74,18 @@ describe('ref injection on iOS new-arch', () => {
       });
     }
   });
+
+  it('does not throw when cloneElement runs with a typeless element (type != null guard before type.$$typeof)', () => {
+    // React.cloneElement forwards element.type into ReactElement(); a malformed
+    // "element" with no `type` passes undefined. The plugin injects fabric ref
+    // logic that must use `type != null ? type.$$typeof : undefined` — otherwise
+    // accessing type.$$typeof throws (matches NonJsxElements manual repro).
+    const fakeElement = { dummy: true, children: [], props: {} };
+
+    expect(() => {
+      React.cloneElement(fakeElement, { key: 0 });
+    }).not.toThrow();
+
+    expect(global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef).toBe(true);
+  });
 });

--- a/__tests__/runtime/fabricRef.test.js
+++ b/__tests__/runtime/fabricRef.test.js
@@ -75,11 +75,9 @@ describe('ref injection on iOS new-arch', () => {
     }
   });
 
-  it('does not throw when cloneElement runs with a typeless element (type != null guard before type.$$typeof)', () => {
+  it('does not throw when cloneElement runs with a typeless element', () => {
     // React.cloneElement forwards element.type into ReactElement(); a malformed
-    // "element" with no `type` passes undefined. The plugin injects fabric ref
-    // logic that must use `type != null ? type.$$typeof : undefined` — otherwise
-    // accessing type.$$typeof throws (matches NonJsxElements manual repro).
+    // "element" with no `type` passes undefined.
     const fakeElement = { dummy: true, children: [], props: {} };
 
     expect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef === undefined) {
   global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef = (global.RN$Bridgeless || global.__turboModuleProxy != null) && Platform.OS === 'ios' && !Platform.isTV;
 }
 if (global.__FULLSTORY_BABEL_PLUGIN_shouldInjectRef) {
-  const typeSymbol = ${typeIdentifier}.$$typeof;
+  const typeSymbol = ${typeIdentifier} != null ? ${typeIdentifier}.$$typeof : undefined;
   const typeString = typeSymbol ? typeSymbol.toString() : '';
   const isValidType = ${IS_REACT_19_PLUS} || (typeString === 'Symbol(react.forward_ref)' || typeString === 'Symbol(react.element)' || typeString === 'Symbol(react.transitional.element)');
   if (isValidType && ${propsIdentifier}) {


### PR DESCRIPTION
https://fullstory.atlassian.net/browse/VAL-10139

From the ticket, `react-i18next` can create a component with an undefined `type`. I've managed to replicate this error [here](https://github.com/cowpaths/mn/pull/102790). The fix is to guard against `type` being `undefined`.