### PR TITLE
fix: keep synthetic refs enumerable so they propagate through {...props} spread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- React 19: revert synthetic `ref` injection to enumerable so it propagates through `{...props}` spreads used by `Animated.createAnimatedComponent` and similar ref-forwarding HOCs. Non-enumerable refs (introduced in 1.6.3) silently dropped through these HOCs and broke downstream scroll-lifecycle callbacks on iOS new architecture. Consumers who want to prevent the synthetic ref from leaking through `{...rest}` can destructure `ref` explicitly.
+
 ## 1.6.4
 
 - Fixed a bug where a component with an undefined `type` causes a runtime exception.

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactDevelopment_react19/output.js
@@ -481,7 +481,7 @@
                     props['ref'],
                     hasFSDynamicAttribute,
                   ),
-                  enumerable: false,
+                  enumerable: true,
                   configurable: true,
                 },
               );

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeDevelopment_react19/output.js
@@ -415,7 +415,7 @@
                     props['ref'],
                     hasFSDynamicAttribute,
                   ),
-                  enumerable: false,
+                  enumerable: true,
                   configurable: true,
                 },
               );

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactJsxRuntimeProduction_react19/output.js
@@ -67,7 +67,7 @@ function jsxProd(type, config, maybeKey) {
                 maybeKey['ref'],
                 hasFSDynamicAttribute,
               ),
-              enumerable: false,
+              enumerable: true,
               configurable: true,
             },
           );

--- a/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
+++ b/__tests__/fixtures/react-native/fabricRefRewrites/reactProduction_react19/output.js
@@ -123,7 +123,7 @@ function ReactElement(type, key, self, source, owner, props) {
                 props['ref'],
                 hasFSDynamicAttribute,
               ),
-              enumerable: false,
+              enumerable: true,
               configurable: true,
             },
           );

--- a/__tests__/runtime/fabricRef.test.js
+++ b/__tests__/runtime/fabricRef.test.js
@@ -35,19 +35,42 @@ describe('ref injection on iOS new-arch', () => {
     });
   });
 
-  it('injected ref on a custom component is non-enumerable and does not appear in {...rest} spreads', () => {
-    // Regression test for: when a custom (non-host) component receives FS attributes,
-    // the babel plugin injects a `ref` into its props object. In React 19 props are
-    // plain objects, so a regular enumerable `ref` would leak into `{...rest}` spreads
-    // and be passed down to host components that don't accept it, breaking the tree.
-    // The fix defines the injected `ref` as non-enumerable so it is invisible to spreads.
+  it('injected ref propagates through {...props} spread to forwarded child components', () => {
+    // Regression test for: HOCs that intentionally forward refs to a single
+    // inner component via `{...props}` spread (notably Reanimated's
+    // `Animated.createAnimatedComponent`) must see the synthetic ref. Defining
+    // it as non-enumerable would silently drop the ref into those HOCs and
+    // break downstream scroll-lifecycle callbacks and other ref-dependent
+    // behavior on iOS new arch + React 19.
+    //
+    // Trade-off: consumers who use the `const { ref, ...rest } = props; <Child {...rest} />`
+    // pattern can opt out by destructuring `ref` explicitly. See the
+    // sibling test below.
+    const childRef = React.createRef();
+
+    const HOCComponent = props => {
+      // Forwarding pattern used by Animated.createAnimatedComponent and many
+      // ref-forwarding HOCs: spread everything (including the synthetic ref)
+      // to a single inner host component.
+      return <View {...props} />;
+    };
+
+    render(<HOCComponent fsClass="hoc-class" ref={childRef} />);
+
+    expect(childRef.current).not.toBeNull();
+    expect(childRef.current?._reactInternals?.type).toBe(View);
+  });
+
+  it('consumers can opt out of synthetic-ref propagation by destructuring `ref`', () => {
+    // Consumers that wrap a host component and don't want the synthetic ref
+    // (or any other unknown ref) to reach the host can destructure it out
+    // before spreading the remainder.
     const childRef = React.createRef();
 
     const CustomComponent = props => {
-      const { fsClass: _fsClass, ...rest } = props;
-      // If `ref` were enumerable it would end up in `rest` and be forwarded to
-      // the inner <View>, overriding childRef and causing childRef.current to
-      // remain null (or point to the wrong node).
+      // Explicitly destructure both `ref` and `fsClass` out of props so they
+      // don't leak into `rest`.
+      const { ref: _ref, fsClass: _fsClass, ...rest } = props;
       return <View ref={childRef} {...rest} />;
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const setRefBackwardCompat = (refIdentifier, propsIdentifier, moduleRef, hasDyna
     // React versions < 19
     return `${refIdentifier} = ${moduleRef}.applyFSPropertiesWithRef(${refIdentifier}, ${hasDynamicAttribute});`;
   }
-  // React versions >= 19 — synthetic refs are non-enumerable to prevent leaking through {...rest} spreads
+  // React versions >= 19 — synthetic ref must remain enumerable so it propagates
   return `if (!${propsIdentifier}['ref'] && ${propsIdentifier}['forwardedRef']) {
     ${propsIdentifier} = { ...${propsIdentifier} };
   } else {
@@ -28,7 +28,7 @@ const setRefBackwardCompat = (refIdentifier, propsIdentifier, moduleRef, hasDyna
       'ref',
       {
         value: ${moduleRef}.applyFSPropertiesWithRef(${propsIdentifier}['ref'], ${hasDynamicAttribute}),
-        enumerable: false,
+        enumerable: true,
         configurable: true,
       }
     );


### PR DESCRIPTION
## Summary

#64 (shipped in 1.6.3) made synthetic ref injection on React 19 + iOS new architecture **non-enumerable** via `Object.defineProperty(..., { enumerable: false })` to prevent the ref from leaking through `{...rest}` spreads.

The side effect: HOCs that intentionally forward refs to a single inner component via `{...props}` spread can no longer see the ref. The most prominent example is `Animated.createAnimatedComponent(Component)` from `react-native-reanimated`, which uses prop spreading to forward refs to the wrapped component. With the synthetic ref non-enumerable, the inner component never receives the ref, and downstream behaviors that depend on that ref binding (scroll-lifecycle callbacks like `onScrollBeginDrag`, `onMomentumScrollEnd`, gesture coordination, etc.) silently break.

This PR restores the 1.6.2 behavior of making the synthetic ref enumerable. The trade-off (consumers who use the `const { /* not ref */, ...rest } = props; <Child {...rest} />` pattern can see the synthetic ref leak into `rest`) is documented in the comment and CHANGELOG, and is opt-out: consumers who want the old behavior can destructure `ref` explicitly, the same way they would for any other prop they don't want forwarded.

## Reproduction

The bug surfaces in any animated horizontal/vertical scroll carousel built on a `react-native-gesture-handler` `FlatList` wrapped by `Animated.createAnimatedComponent` and driven by `useAnimatedScrollHandler`. After the first scroll/drag, subsequent `onScrollBeginDrag`-derived event paths stop firing. Scroll content still moves natively (RNGH does its own scroll), but JS-side scroll-lifecycle callbacks freeze.

```tsx
import React, { useRef } from 'react';
import { View } from 'react-native';
import { FlatList } from 'react-native-gesture-handler';
import Animated, {
  useAnimatedScrollHandler,
  useAnimatedReaction,
  useSharedValue,
} from 'react-native-reanimated';
import { scheduleOnRN } from 'react-native-worklets';

const AnimatedFlatList = Animated.createAnimatedComponent(FlatList);

export const ReproCarousel = () => {
  const scrollX = useSharedValue(0);
  const isManuallyScrolling = useRef(false);

  const onScroll = useAnimatedScrollHandler(
    { onScroll: e => { scrollX.value = e.contentOffset.x; } },
    [],
  );

  const onDragChange = (x: number) => {
    if (isManuallyScrolling.current) {
      // Expected: fires throughout every swipe (drag + momentum)
      // Actual on 1.6.3+: only fires on the FIRST swipe; subsequent swipes silent
      console.log('index changed at scrollX:', x);
    }
  };

  useAnimatedReaction(
    () => scrollX.value,
    x => { scheduleOnRN(onDragChange, x); },
  );

  return (
    <AnimatedFlatList
      horizontal
      data={[0, 1, 2, 3]}
      keyExtractor={i => String(i)}
      onScroll={onScroll}
      onScrollBeginDrag={() => { isManuallyScrolling.current = true; }}
      onMomentumScrollEnd={() => { isManuallyScrolling.current = false; }}
      snapToInterval={200}
      renderItem={() => <View style={{ width: 200, height: 200 }} />}
    />
  );
};
```

**Steps**

1. Render `<ReproCarousel />` in an iOS new-arch + React 19 app with `@fullstory/babel-plugin-react-native` ≥ 1.6.3 in the babel config.
2. Swipe horizontally from item 0 to item 1 — `console.log('index changed at scrollX', x)` fires throughout.
3. Swipe again from item 1 to item 2 — log line **does not fire**. `onScrollBeginDrag` did not run, so `isManuallyScrolling.current` stays `false` for the entire second swipe.

## Bisect

- Disabling only `@fullstory/babel-plugin-react-native` (leaving `@fullstory/babel-plugin-annotate-react` enabled) restores correct behavior on 1.6.3.
- Pinning to 1.6.2 restores correct behavior.
- The diff between 1.6.2 and 1.6.3 in the relevant code path is exactly the change introduced by #64.

## Root cause

`Object.defineProperty(props, 'ref', { value, enumerable: false, configurable: true })` defines a non-enumerable `ref` property. `Object.assign`, `{...props}` spread, and `for...in` iteration all skip non-enumerable properties. So:

- React's element-creation path still reads `element.props.ref` via direct property access — works.
- HOCs that forward via `{...props}` (Reanimated's `createAnimatedComponent` and many others) — the ref doesn't make it across.

## Why this trade-off

The pattern broken by 1.6.3 (HOCs forwarding refs through `{...props}` spread) is structural — it's how Reanimated and many ref-forwarding wrappers are written, and consumers cannot rewrite those upstream APIs. The pattern protected by 1.6.3 (avoiding ref leakage through `{...rest}` after destructuring other attributes) is an opt-out: consumers who want to prevent the synthetic ref from leaking through `rest` can destructure `ref` explicitly:

```diff
- const { fsClass, ...rest } = props;
+ const { ref, fsClass, ...rest } = props;
  return <View ref={childRef} {...rest} />;
```

Making the destructure opt-out the responsibility of the consumer is consistent with how React props normally work — consumers are expected to know which props they want to forward and which they want to extract.

## Changes

- `src/index.js` — `enumerable: false` → `enumerable: true` in the React 19 ref injection path, with updated comment.
- `__tests__/runtime/fabricRef.test.js` — replaced the 1.6.3 regression test with two tests: one positive test showing the synthetic ref propagates through `{...props}` spread (the fix), and one showing how consumers can opt out by destructuring `ref` explicitly.
- `__tests__/fixtures/.../output.js` — updated expected output to match the new emission.
- `CHANGELOG.md` — Unreleased entry explaining the change and the trade-off.

## Alternative — "both worlds"

If preserving the original `{...rest}` non-leakage behavior in 1.6.3 without breaking spread forwarding is desired, one option is to set the synthetic ref via both a non-enumerable canonical property and an enumerable shallow copy. This is more code and more cognitive overhead; I'm happy to explore it as a follow-up if you'd prefer that direction over the simpler revert in this PR.

## Workspace note

We're currently patching the plugin locally (this same one-character change) to ship a fix in our app. We'd like to move back to an official version, so this PR is primarily about surfacing the bug and getting feedback on the right direction. Happy to iterate on the fix shape.