### PR TITLE
fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fullstory/babel-plugin-react-native",
   "version": "1.6.4",
   "description": "The official FullStory React Native babel plugin",
-  "repository": "git://github.com/fullstorydev/fullstory-babel-plugin-react-native.git",
+  "repository": "git+https://github.com/fullstorydev/fullstory-babel-plugin-react-native.git",
   "homepage": "https://github.com/fullstorydev/fullstory-babel-plugin-react-native",
   "author": "FullStory",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- update the npm package repository metadata from the deprecated `git://` protocol to a GitHub HTTPS URL

## Validation

- parsed `package.json` and confirmed `repository` is `git+https://github.com/fullstorydev/fullstory-babel-plugin-react-native.git`
- ran `npm pack --dry-run --ignore-scripts --json`
- ran `git diff --check`
