### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0
+
+- iOS New Architecture (Fabric): migrated from ref rewriting to a commit-phase hook (`commitMutationEffectsOnFiber`) that batches and applies FS properties after the Fabric shadow tree is committed to native.
+
 ## 1.6.4
 
 - Fixed a bug where a component with an undefined `type` causes a runtime exception.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/babel-plugin-react-native",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/babel-plugin-react-native",
-      "version": "1.6.4",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/babel-plugin-react-native",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "description": "The official FullStory React Native babel plugin",
   "repository": "git+https://github.com/fullstorydev/fullstory-babel-plugin-react-native.git",
   "homepage": "https://github.com/fullstorydev/fullstory-babel-plugin-react-native",


### PR DESCRIPTION
Tested sessions and ensured that selectors stay in the same:

Old implementation: https://app.staging.fullstory.com/ui/3RWN/session/6931349912851457513:4631609143069378314
New implementation: https://app.staging.fullstory.com/ui/3RWN/session/6931349912851457513:5056984164100916681

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The diff only updates version metadata and changelog; no runtime or plugin logic changes in this PR itself.
> 
> **Overview**
> **Release 1.7.0** bumps `@fullstory/babel-plugin-react-native` from **1.6.4** to **1.7.0** in `package.json` and `package-lock.json`.
> 
> The **CHANGELOG** entry for 1.7.0 documents the headline change in this line: on **iOS New Architecture (Fabric)**, FullStory attribute handling moves from **ref rewriting** to a **commit-phase hook** on `commitMutationEffectsOnFiber`, which **batches and applies FS properties after** the Fabric shadow tree is committed to native. The PR description notes staging validation that **selectors stayed consistent** between the old and new approaches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28225b7d995078c8f94c863272664ea873e8259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->